### PR TITLE
source_selector_test.cpp: supress warning in one test case

### DIFF
--- a/bftengine/tests/bcstatetransfer/source_selector_test.cpp
+++ b/bftengine/tests/bcstatetransfer/source_selector_test.cpp
@@ -276,6 +276,9 @@ TEST_F(SourceSelectorTestFixture, change_source_after_too_many_retransmissions) 
 }  // namespace
 
 int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  testing::FLAGS_gtest_death_test_style =
+      "threadsafe";  // mitigate the risks of testing in a possibly multithreaded environment
+
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Testcase cannot_select_source_without_initial_replicas had a warning
on the death assertion, which might be problematic when there are
multiple thereads.
We had to solve it by changing death test style to threadsafe.