### PR TITLE
BCStateTran: run state transfer main always as separate thread

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -167,7 +167,6 @@ struct Config {
   uint32_t metricsDumpIntervalSec = 0;
 
   // misc
-  bool runInSeparateThread = false;
   bool enableReservedPages = true;
   bool enableSourceBlocksPreFetch = true;
 };
@@ -195,7 +194,6 @@ inline std::ostream &operator<<(std::ostream &os, const Config &c) {
               c.fetchRetransmissionTimeoutMs,
               c.maxFetchRetransmissions,
               c.metricsDumpIntervalSec,
-              c.runInSeparateThread,
               c.enableReservedPages,
               c.enableSourceBlocksPreFetch);
   return os;

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -114,12 +114,13 @@ class BCStateTran : public IStateTransfer {
   void saveReservedPage(uint32_t reservedPageId, uint32_t copyLength, const char* inReservedPage) override;
   void zeroReservedPage(uint32_t reservedPageId) override;
 
-  void onTimer() override { timerHandler_(); };
-
+  // Handoff API- handle timeouts and messages from an external context
+  void onTimer() override { handoff_->push(std::bind(&BCStateTran::onTimerImp, this)); };
   using LocalTimePoint = time_point<steady_clock>;
   static constexpr auto UNDEFINED_LOCAL_TIME_POINT = LocalTimePoint::max();
   void handleStateTransferMessage(char* msg, uint32_t msgLen, uint16_t senderId) override {
-    messageHandler_(msg, msgLen, senderId, UNDEFINED_LOCAL_TIME_POINT);
+    handoff_->push(std::bind(
+        &BCStateTran::handleStateTransferMessageImp, this, msg, msgLen, senderId, std::chrono::steady_clock::now()));
   };
 
   std::string getStatus() override;
@@ -143,20 +144,12 @@ class BCStateTran : public IStateTransfer {
 
  protected:
   // handling messages from other context
-  std::function<void(char*, uint32_t, uint16_t, LocalTimePoint)> messageHandler_;
   void handleStateTransferMessageImp(char* msg,
                                      uint32_t msgLen,
                                      uint16_t senderId,
                                      LocalTimePoint msgArrivalTime = UNDEFINED_LOCAL_TIME_POINT);
-  void handoffMsg(char* msg, uint32_t msgLen, uint16_t senderId) {
-    handoff_->push(
-        std::bind(&BCStateTran::handleStateTransferMessageImp, this, msg, msgLen, senderId, steady_clock::now()));
-  }
-
   // handling timer from other context
-  std::function<void()> timerHandler_;
   void onTimerImp();
-  void handoffTimer() { handoff_->push(std::bind(&BCStateTran::onTimerImp, this)); }
 
   ///////////////////////////////////////////////////////////////////////////
   // Constants

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -327,7 +327,6 @@ SimpleStateTran::SimpleStateTran(
       2000,                                 // fetchRetransmissionTimeoutMs
       2,                                    // maxFetchRetransmissions
       5,                                    // metricsDumpIntervalSec
-      true,                                 // runInSeparateThread
       true,                                 // enableReservedPages
       true                                  // enableSourceBlocksPreFetch
   };

--- a/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
+++ b/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
@@ -81,7 +81,6 @@ Config targetConfig() {
       2000,               // fetchRetransmissionTimeoutMs
       2,                  // maxFetchRetransmissions
       5,                  // metricsDumpIntervalSec
-      false,              // runInSeparateThread
       true,               // enableReservedPages
       true                // enableSourceBlocksPreFetch
   };

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -487,7 +487,6 @@ Replica::Replica(ICommunication *comm,
     replicaConfig_.get<uint32_t>("concord.bft.st.fetchRetransmissionTimeoutMs", 2000),
     replicaConfig_.get<uint32_t>("concord.bft.st.maxFetchRetransmissions", 2),
     replicaConfig_.get<uint32_t>("concord.bft.st.metricsDumpIntervalSec", 5),
-    replicaConfig_.get("concord.bft.st.runInSeparateThread", replicaConfig_.isReadOnly),
     replicaConfig_.get("concord.bft.st.enableReservedPages", true),
     replicaConfig_.get("concord.bft.st.enableSourceBlocksPreFetch", true)
   };

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -70,7 +70,6 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     replicaConfig.batchedPreProcessEnabled = true;
     replicaConfig.timeServiceEnabled = false;
     replicaConfig.set("sourceReplicaReplacementTimeoutMilli", 6000);
-    replicaConfig.set("concord.bft.st.runInSeparateThread", true);
     replicaConfig.set("concord.bft.keyExchage.clientKeysEnabled", false);
     replicaConfig.preExecutionResultAuthEnabled = false;
     const auto persistMode = PersistencyMode::RocksDB;


### PR DESCRIPTION
Here we cancel the configuration parameter runInSeparateThread.
That means, runInSeparateThread=true always.
Running as a single thread is not feasible, and might create serious
issue, especially in source replica.