### PR TITLE
Source selector configurable primary awareness

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -170,6 +170,7 @@ struct Config {
   // misc
   bool enableReservedPages = true;
   bool enableSourceBlocksPreFetch = true;
+  bool enableSourceSelectorPrimaryAwareness = true;
 };
 
 inline std::ostream &operator<<(std::ostream &os, const Config &c) {
@@ -198,7 +199,8 @@ inline std::ostream &operator<<(std::ostream &os, const Config &c) {
               c.maxFetchRetransmissions,
               c.metricsDumpIntervalSec,
               c.enableReservedPages,
-              c.enableSourceBlocksPreFetch);
+              c.enableSourceBlocksPreFetch,
+              c.enableSourceSelectorPrimaryAwareness);
   return os;
 }
 // creates an instance of the state transfer module.

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -3119,7 +3119,9 @@ void BCStateTran::peekConsensusMessage(shared_ptr<ConsensusMsg> &msg) {
 
   switch (msg_type) {
     case MsgCode::PrePrepare:
-      sourceSelector_.updateCurrentPrimary(msg->sender_id_);
+      if (config_.enableSourceSelectorPrimaryAwareness) {
+        sourceSelector_.updateCurrentPrimary(msg->sender_id_);
+      }
       break;
     default:
       LOG_FATAL(logger_, "Unexpected message type" << KVLOG(msg_type));

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -332,7 +332,8 @@ SimpleStateTran::SimpleStateTran(
       2,                                    // maxFetchRetransmissions
       5,                                    // metricsDumpIntervalSec
       true,                                 // enableReservedPages
-      true                                  // enableSourceBlocksPreFetch
+      true,                                 // enableSourceBlocksPreFetch
+      true                                  // enableSourceSelectorPrimaryAwareness
   };
 
   auto comparator = concord::storage::memorydb::KeyComparator();

--- a/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
+++ b/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
@@ -95,7 +95,8 @@ Config targetConfig() {
       2,                  // maxFetchRetransmissions
       5,                  // metricsDumpIntervalSec
       true,               // enableReservedPages
-      true                // enableSourceBlocksPreFetch
+      true,               // enableSourceBlocksPreFetch
+      true                // enableSourceSelectorPrimaryAwareness
   };
 }
 

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -485,7 +485,8 @@ Replica::Replica(ICommunication *comm,
     replicaConfig_.get<uint32_t>("concord.bft.st.maxFetchRetransmissions", 2),
     replicaConfig_.get<uint32_t>("concord.bft.st.metricsDumpIntervalSec", 5),
     replicaConfig_.get("concord.bft.st.enableReservedPages", true),
-    replicaConfig_.get("concord.bft.st.enableSourceBlocksPreFetch", true)
+    replicaConfig_.get("concord.bft.st.enableSourceBlocksPreFetch", true),
+    replicaConfig_.get("concord.bft.st.enableSourceSelectorPrimaryAwareness", true)
   };
 
 #if !defined USE_COMM_PLAIN_TCP && !defined USE_COMM_TLS_TCP


### PR DESCRIPTION
This PR adds:
- a new configuration parameter that allows the source selector's primary awareness to be enabled or disabled
- an unit test that verifies the capability mentioned above