### PR TITLE
Introducing Range Validation Tree (RVT) in State Transfer

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -42,6 +42,7 @@ set(corebft_source_files
     src/bcstatetransfer/DBDataStore.cpp
     src/bcstatetransfer/SourceSelector.cpp
     src/bcstatetransfer/AsyncStateTransferCRE.cpp
+    src/bcstatetransfer/RangeValidationTree.cpp
     src/simplestatetransfer/SimpleStateTran.cpp
     src/bftengine/messages/PrePrepareMsg.cpp
     src/bftengine/messages/CheckpointMsg.cpp

--- a/bftengine/src/bcstatetransfer/RangeValidationTree.cpp
+++ b/bftengine/src/bcstatetransfer/RangeValidationTree.cpp
@@ -1,0 +1,910 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include <queue>
+#include <algorithm>
+
+#include "RangeValidationTree.hpp"
+#include "STDigest.hpp"
+
+using namespace std;
+using namespace concord::serialize;
+
+namespace bftEngine::bcst::impl {
+
+using NodeVal = RangeValidationTree::NodeVal;
+using NodeVal_t = CryptoPP::Integer;
+using RVTNode = RangeValidationTree::RVTNode;
+using RVBNode = RangeValidationTree::RVBNode;
+using NodeInfo = RangeValidationTree::NodeInfo;
+using RVTNodePtr = RangeValidationTree::RVTNodePtr;
+
+/////////////////////////////////////////// NodeVal Operations ////////////////////////////////////////////////
+
+NodeVal_t NodeVal::calcMaxValue(size_t val_size) {
+  NodeVal_t v = NodeVal_t(1);
+  v = (v << (val_size * 8ULL)) - NodeVal_t(1);
+  return v;
+}
+
+NodeVal_t NodeVal::calcModulo(size_t val_size) {
+  NodeVal_t v = NodeVal_t(1);
+  v = v << (val_size * 8ULL);
+  return v;
+}
+
+NodeVal_t NodeVal::kNodeValueMax_ = 0;
+NodeVal_t NodeVal::kNodeValueModulo_ = 0;
+
+NodeVal::NodeVal(const shared_ptr<char[]>&& val, size_t size) {
+  val_ = NodeVal_t(reinterpret_cast<unsigned char*>(val.get()), size) % kNodeValueModulo_;
+}
+
+NodeVal::NodeVal(const char* val_ptr, size_t size) {
+  val_ = NodeVal_t(reinterpret_cast<const unsigned char*>(val_ptr), size) % kNodeValueModulo_;
+}
+
+NodeVal::NodeVal(const NodeVal_t* val) { val_ = (*val) % kNodeValueModulo_; }
+
+NodeVal::NodeVal(const NodeVal_t& val) { val_ = (val) % kNodeValueModulo_; }
+
+NodeVal::NodeVal(const NodeVal_t&& val) { val_ = (val) % kNodeValueModulo_; }
+
+NodeVal::NodeVal() : val_{(int64_t)0} {}
+
+NodeVal& NodeVal::operator+=(const NodeVal& other) {
+  val_ = (val_ + other.val_) % kNodeValueModulo_;
+  return *this;
+}
+
+NodeVal& NodeVal::operator-=(const NodeVal& other) {
+  val_ = ((val_ - other.val_) % kNodeValueModulo_);
+  return *this;
+}
+
+bool NodeVal::operator!=(const NodeVal& other) { return (val_ != other.val_); }
+
+bool NodeVal::operator==(const NodeVal& other) { return (val_ == other.val_); }
+
+// Used only to print
+std::string NodeVal::toString() const noexcept {
+  std::ostringstream oss;
+  // oss << std::dec << val_;
+  oss << std::hex << val_;
+  return oss.str();
+}
+
+std::string NodeVal::getDecoded() const noexcept {
+  // Encode to string does not work
+  vector<char> enc_input(val_.MinEncodedSize());
+  val_.Encode(reinterpret_cast<CryptoPP::byte*>(enc_input.data()), enc_input.size());
+  ostringstream oss_en;
+  for (auto& c : enc_input) {
+    oss_en << c;
+  }
+  return oss_en.str();
+}
+//////////////////////////////// End of NodeVal operations ///////////////////////////////////////
+
+std::string NodeInfo::toString() const noexcept {
+  std::ostringstream os;
+  os << " [" << level << "," << rvb_index << "]";
+  return os.str();
+}
+
+uint32_t RVBNode::RVT_K{};
+
+// TODO - for now, the outDigest is of a fixed size. We can match the final size to RangeValidationTree::value_size
+// This requires us to write our own DigestContext
+const shared_ptr<char[]> RVBNode::computeNodeInitialValue(NodeInfo& node_info, const char* data, size_t data_size) {
+  ConcordAssertGT(node_info.id, 0);
+  DigestContext c;
+
+  c.update(reinterpret_cast<const char*>(&node_info.id), sizeof(node_info.id));
+  c.update(data, data_size);
+  // TODO - Use default_delete in case memleak is reported by ASAN
+  static std::shared_ptr<char[]> outDigest(new char[NodeVal::kDigestContextOutputSize]);
+  c.writeDigest(outDigest.get());
+  return outDigest;
+}
+
+void RangeValidationTree::RVTMetadata::staticAssert() noexcept {
+  static_assert(sizeof(RVTMetadata::magic_num) == sizeof(RangeValidationTree::magic_num_));
+  static_assert(sizeof(RVTMetadata::version_num) == sizeof(RangeValidationTree::version_num_));
+  static_assert(sizeof(RVTMetadata::RVT_K) == sizeof(RangeValidationTree::RVT_K));
+  static_assert(sizeof(RVTMetadata::fetch_range_size) == sizeof(RangeValidationTree::fetch_range_size_));
+  static_assert(sizeof(RVTMetadata::value_size) == sizeof(RangeValidationTree::value_size_));
+}
+
+void RangeValidationTree::SerializedRVTNode::staticAssert() noexcept {
+  static_assert(sizeof(SerializedRVTNode::id) == sizeof(NodeInfo::id));
+  static_assert(sizeof(SerializedRVTNode::n_child) == sizeof(RVTNode::n_child));
+  static_assert(sizeof(SerializedRVTNode::min_child_id) == sizeof(RVTNode::min_child_id));
+  static_assert(sizeof(SerializedRVTNode::max_child_id) == sizeof(RVTNode::max_child_id));
+  static_assert(sizeof(SerializedRVTNode::parent_id) == sizeof(RVTNode::parent_id));
+}
+
+void RVBNode::logInfoVal(const std::string& prefix) {
+  // uncomment to debug
+  // ostringstream oss;
+  // oss << prefix << info_.toString() << " " << current_value_.toString();
+  // LOG_ERROR(GL, oss.str());
+}
+
+RVBNode::RVBNode(uint64_t rvb_index, const char* data, size_t data_size)
+    : info_(kDefaultRVBLeafLevel, rvb_index),
+      current_value_(computeNodeInitialValue(info_, data, data_size), NodeVal::kDigestContextOutputSize) {
+  // logInfoVal("construct: ");
+}
+
+RVBNode::RVBNode(uint8_t level, uint64_t rvb_index)
+    : info_(level, rvb_index),
+      current_value_(
+          computeNodeInitialValue(info_, NodeVal::initialValueZeroData.data(), NodeVal::kDigestContextOutputSize),
+          NodeVal::kDigestContextOutputSize) {}
+
+RVBNode::RVBNode(uint64_t node_id, char* val_ptr, size_t size) : info_(node_id), current_value_(val_ptr, size) {}
+
+RVTNode::RVTNode(const shared_ptr<RVBNode>& node)
+    : RVBNode(kDefaultRVTLeafLevel, node->info_.rvb_index),
+      min_child_id{node->info_.rvb_index},
+      max_child_id{node->info_.rvb_index + RVT_K - 1},
+      initial_value_(current_value_) {
+  n_child++;
+}
+
+RVTNode::RVTNode(const RVTNodePtr& node)
+    : RVBNode(node->info_.level + 1, node->info_.rvb_index), initial_value_(current_value_) {
+  n_child++;
+  auto level = node->info_.level;
+  min_child_id = node->info_.id;
+  uint64_t rvb_index = node->info_.rvb_index + RangeValidationTree::pow_uint(RVT_K, level + 1) -
+                       RangeValidationTree::pow_uint(RVT_K, level);
+  max_child_id = NodeInfo(level, rvb_index).id;
+  ConcordAssert(n_child <= RVT_K);
+  // logInfoVal("construct: ");
+}
+
+RVTNode::RVTNode(SerializedRVTNode& node, char* cur_val_ptr, size_t cur_value_size)
+    : RVBNode(node.id, cur_val_ptr, cur_value_size),
+      n_child{node.n_child},
+      min_child_id{node.min_child_id},
+      max_child_id{node.max_child_id},
+      parent_id{node.parent_id},
+      initial_value_(
+          computeNodeInitialValue(info_, NodeVal::initialValueZeroData.data(), NodeVal::kDigestContextOutputSize),
+          NodeVal::kDigestContextOutputSize) {}
+
+void RVTNode::addValue(const NodeVal& nvalue) { this->current_value_ += nvalue; }
+
+void RVTNode::substractValue(const NodeVal& nvalue) { this->current_value_ -= nvalue; }
+
+std::ostringstream RVTNode::serialize() const {
+  std::ostringstream os;
+  Serializable::serialize(os, n_child);
+  Serializable::serialize(os, min_child_id);
+  Serializable::serialize(os, max_child_id);
+  Serializable::serialize(os, parent_id);
+
+  Serializable::serialize(os, current_value_.getSize());
+  auto decoded_val = current_value_.getDecoded();
+  Serializable::serialize(os, decoded_val.data(), current_value_.getSize());
+
+  // We do not serialize initial_value_ since it can be easily re-calculated
+  return os;
+}
+
+RVTNodePtr RVTNode::createFromSerialized(std::istringstream& is) {
+  SerializedRVTNode snode;
+  Serializable::deserialize(is, snode.id);
+  Serializable::deserialize(is, snode.n_child);
+  Serializable::deserialize(is, snode.min_child_id);
+  Serializable::deserialize(is, snode.max_child_id);
+  Serializable::deserialize(is, snode.parent_id);
+
+  Serializable::deserialize(is, snode.current_value_encoded_size);
+  std::unique_ptr<char[]> ptr_cur = std::make_unique<char[]>(snode.current_value_encoded_size);
+  Serializable::deserialize(is, ptr_cur.get(), snode.current_value_encoded_size);
+  return std::make_shared<RVTNode>(snode, ptr_cur.get(), snode.current_value_encoded_size);
+}
+
+RangeValidationTree::RangeValidationTree(const logging::Logger& logger,
+                                         uint32_t RVT_K,
+                                         uint32_t fetch_range_size,
+                                         size_t value_size)
+    : rightmostRVTNode_{},
+      leftmostRVTNode_{},
+      logger_(logger),
+      RVT_K(RVT_K),
+      fetch_range_size_(fetch_range_size),
+      value_size_(value_size) {
+  NodeVal::kNodeValueMax_ = NodeVal::calcMaxValue(value_size_);
+  NodeVal::kNodeValueModulo_ = NodeVal::calcModulo(value_size_);
+  ConcordAssertEQ(NodeVal::kNodeValueMax_ + NodeVal_t(1), NodeVal::kNodeValueModulo_);
+  ConcordAssert(NodeVal::kNodeValueMax_ != NodeVal_t(static_cast<signed long>(0)));
+  ConcordAssert(NodeVal::kNodeValueModulo_ != NodeVal_t(static_cast<signed long>(0)));
+  ConcordAssertLE(RVT_K, static_cast<uint64_t>(1ULL << (sizeof(RVTNode::n_child) * 8ULL)));
+  RVTMetadata::staticAssert();
+  SerializedRVTNode::staticAssert();
+  RVBNode::RVT_K = RVT_K;
+}
+
+uint64_t RangeValidationTree::pow_uint(uint64_t base, uint64_t exp) noexcept {
+  ConcordAssertOR(base != 0, exp != 0);  // both zero are undefined
+  uint64_t res{base};
+  if (base == 0) {
+    return 0;
+  }
+  if (exp == 0) {
+    return 1;
+  }
+  for (size_t i{1}; i < exp; ++i) {
+    res *= base;
+  }
+  return res;
+}
+
+bool RangeValidationTree::validateTreeStructure() const noexcept { return true; }
+
+bool RangeValidationTree::validateTreeValues() const noexcept {
+  if (root_ == nullptr && empty()) {
+    return true;
+  }
+
+  // Currently we do not get any level 0 data from outside, so we cannot validate level 1
+  // TODO - add support for level 1 validation
+  if (totalLevels() <= RVTNode::kDefaultRVTLeafLevel) {
+    return true;
+  }
+
+  // Lets start from level 2
+  size_t current_level{RVTNode::kDefaultRVTLeafLevel + 1};
+  auto current_node = leftmostRVTNode_[current_level];
+  ConcordAssert(current_node != nullptr);
+
+  do {
+    NodeVal sum_of_childs{};
+    auto child_node = getLeftMostChildNode(current_node);
+    ConcordAssert(child_node != nullptr);
+
+    for (uint16_t i = 0; i < current_node->n_child; ++i) {
+      sum_of_childs += child_node->current_value_;
+      child_node = getRVTNodeOfRightSibling(child_node);
+      if (i < current_node->n_child - 1) {
+        ConcordAssert(child_node != nullptr);
+      }
+    }
+
+    // Forumula:
+    // Every node has an initial value and current value.
+    // A correct value for a node is such that:
+    // ((current value - initial value) % mod) == ((sum of current values of all childs) % mod)
+
+    NodeVal added_to_current{};
+    added_to_current += current_node->current_value_;
+    added_to_current -= current_node->initial_value_;
+    if (added_to_current != sum_of_childs) {
+      LOG_ERROR(logger_,
+                "Value validation failed: info=" << current_node->info_.toString()
+                                                 << " ,curent value=" << current_node->current_value_.toString()
+                                                 << " ,initial value=" << current_node->initial_value_.toString()
+                                                 << " ,sum of childs=" << sum_of_childs.toString()
+                                                 << " ,added_to_current=" << added_to_current.toString());
+      // 1st error found - exit
+      return false;
+    }
+    auto next_sibling = getRVTNodeOfRightSibling(current_node);
+    if (next_sibling == nullptr) {
+      // go 1 level up and leftmost
+      current_node = leftmostRVTNode_[++current_level];
+    } else {
+      current_node = next_sibling;
+    }
+  } while (current_node && current_node->parent_id != 0);
+  return true;
+}
+
+bool RangeValidationTree::validate() const noexcept {
+  if (validateTreeStructure()) {
+    return validateTreeValues();
+  }
+  return false;
+}
+
+void RangeValidationTree::printToLog(bool only_node_id) const noexcept {
+  if (!root_ or totalNodes() == 0) {
+    LOG_INFO(logger_, "Empty RVT");
+    return;
+  }
+  if (totalNodes() > kMaxNodesToPrint) {
+    LOG_WARN(logger_, "Huge tree so would not log");
+    return;
+  }
+  std::ostringstream oss;
+  oss << " #Levels=" << root_->info_.level;
+  oss << " #Nodes=" << totalNodes();
+  oss << " Structure: ";
+  queue<RVTNodePtr> q;
+  q.push(root_);
+  while (q.size()) {
+    auto& node = q.front();
+    q.pop();
+    oss << node->info_.toString() << " ";
+    if (not only_node_id) {
+      oss << " = " << node->current_value_.toString() << " ";
+    }
+    if (node->info_.level == 1) {
+      continue;
+    }
+
+    uint16_t count = 0;
+    auto child_node = getLeftMostChildNode(node);
+    ConcordAssert(child_node != nullptr);
+    while (count++ < node->n_child) {
+      q.push(child_node);
+      child_node = getRVTNodeOfRightSibling(child_node);
+      if (count < node->n_child) {
+        ConcordAssert(child_node != nullptr);
+      }
+    }
+  }
+  LOG_INFO(logger_, oss.str());
+}
+
+bool RangeValidationTree::isValidRvbId(const RVBId& block_id) const noexcept {
+  return ((block_id != 0) && (fetch_range_size_ != 0) && (block_id % fetch_range_size_ == 0));
+}
+
+bool RangeValidationTree::validateRVBGroupId(const RVBGroupId rvb_group_id) const {
+  NodeInfo nid(rvb_group_id);
+  if (rvb_group_id == 0) {
+    return false;
+  }
+  return ((nid.level == RVTNode::kDefaultRVTLeafLevel) && ((nid.rvb_index % RVT_K) == 1));
+}
+
+RVTNodePtr RangeValidationTree::getRVTNodeOfLeftSibling(const RVTNodePtr& node) const {
+  if (leftmostRVTNode_[node->info_.level] == node) {
+    return nullptr;
+  }
+  auto level = node->info_.level;
+  auto rvb_index = node->info_.rvb_index;
+  auto id = NodeInfo(level, rvb_index - RangeValidationTree::pow_uint(RVT_K, level)).id;
+  auto iter = id_to_node_.find(id);
+  return (iter == id_to_node_.end()) ? nullptr : iter->second;
+}
+
+RVTNodePtr RangeValidationTree::getRVTNodeOfRightSibling(const RVTNodePtr& node) const {
+  if (rightmostRVTNode_[node->info_.level] == node) {
+    return nullptr;
+  }
+  auto level = node->info_.level;
+  auto rvb_index = node->info_.rvb_index;
+  auto id = NodeInfo(level, rvb_index + RangeValidationTree::pow_uint(RVT_K, level)).id;
+  auto iter = id_to_node_.find(id);
+  return (iter == id_to_node_.end()) ? nullptr : iter->second;
+}
+
+RVTNodePtr RangeValidationTree::getParentNode(const RVTNodePtr& node) const noexcept {
+  auto itr = id_to_node_.find(node->parent_id);
+  return (itr == id_to_node_.end()) ? nullptr : itr->second;
+}
+
+RVTNodePtr RangeValidationTree::getLeftMostChildNode(const RVTNodePtr& node) const noexcept {
+  auto itr = id_to_node_.find(node->min_child_id);
+  return (itr == id_to_node_.end() ? nullptr : itr->second);
+}
+
+void RangeValidationTree::addRVBNode(const shared_ptr<RVBNode>& rvb_node) {
+  auto parent_node = openForInsertion(RVTNode::kDefaultRVTLeafLevel);
+  if (!parent_node) {
+    // adding first rvb parent_node but it might not be first child (reason: pruning)
+    parent_node = make_shared<RVTNode>(rvb_node);
+    rightmostRVTNode_[RVTNode::kDefaultRVTLeafLevel] = parent_node;
+    if (!leftmostRVTNode_[RVTNode::kDefaultRVTLeafLevel]) {
+      leftmostRVTNode_[RVTNode::kDefaultRVTLeafLevel] = parent_node;
+    }
+    ConcordAssert(id_to_node_.insert({parent_node->info_.id, parent_node}).second == true);
+    if (!root_) {  // TODO - is this needed???
+      setNewRoot(parent_node);
+    }
+    addInternalNode(parent_node);
+  } else {
+    ++parent_node->n_child;
+    ConcordAssertLE(parent_node->n_child, RVT_K);
+    ConcordAssertLE(parent_node->min_child_id + parent_node->n_child - 1, parent_node->max_child_id);
+  }
+  addValueToInternalNodes(parent_node, rvb_node->current_value_);
+}
+
+void RangeValidationTree::removeRVBNode(const shared_ptr<RVBNode>& rvb_node) {
+  auto node = openForRemoval(RVTNode::kDefaultRVTLeafLevel);
+  ConcordAssert(node != nullptr);
+
+  if (node->n_child == 1) {
+    // no more RVB childs, erase the node
+    auto id = node->info_.id;
+    auto node_to_remove_iter = id_to_node_.find(id);
+    ConcordAssert(node_to_remove_iter != id_to_node_.end());
+    if ((node == leftmostRVTNode_[RVTNode::kDefaultRVTLeafLevel]) &&
+        (node == rightmostRVTNode_[RVTNode::kDefaultRVTLeafLevel])) {
+      leftmostRVTNode_[RVTNode::kDefaultRVTLeafLevel] = nullptr;
+      rightmostRVTNode_[RVTNode::kDefaultRVTLeafLevel] = nullptr;
+    } else {
+      if (node == leftmostRVTNode_[RVTNode::kDefaultRVTLeafLevel]) {
+        auto id = NodeInfo(RVTNode::kDefaultRVTLeafLevel, rvb_node->info_.rvb_index + 1).id;
+        auto iter = id_to_node_.find(id);
+        leftmostRVTNode_[RVTNode::kDefaultRVTLeafLevel] = (iter == id_to_node_.end()) ? nullptr : iter->second;
+      }
+      if (node == rightmostRVTNode_[RVTNode::kDefaultRVTLeafLevel]) {
+        rightmostRVTNode_[RVTNode::kDefaultRVTLeafLevel] = nullptr;
+      }
+    }
+    id_to_node_.erase(node_to_remove_iter);
+    auto val_negative = node->initial_value_;
+    val_negative.val_.SetNegative();
+    addValueToInternalNodes(getParentNode(node), val_negative);
+  }
+
+  --node->n_child;
+  if (node->n_child > 0) {
+    ++node->min_child_id;
+  }
+  ConcordAssertLE(node->min_child_id + node->n_child - 1, node->max_child_id);
+  removeAndUpdateInternalNodes(node, rvb_node->current_value_);
+}
+
+void RangeValidationTree::addValueToInternalNodes(const RVTNodePtr& bottom_node, const NodeVal& value) {
+  if (bottom_node == nullptr) return;
+
+  auto current_node = bottom_node;
+  do {
+    current_node->addValue(value);
+    if (current_node->parent_id != 0) {
+      ConcordAssert(root_ != current_node);
+      current_node = getParentNode(current_node);
+      ConcordAssert(current_node != nullptr);
+    } else {
+      ConcordAssert(root_ == current_node);
+    }
+  } while (current_node != root_);
+  if (current_node != bottom_node) {
+    current_node->addValue(value);
+  }
+}
+
+// level 0: RVB node
+// level 1 and above: RVT node
+// first RVT may end up adding few more RVTs in top
+//
+// RVT             1,1             1,4
+//              /   |   \          /
+//             /    |    \        /
+// RVB        0,1  0,2   0,3     0,4
+
+void RangeValidationTree::addInternalNode(const RVTNodePtr& node_to_add) {
+  RVTNodePtr parent_node, bottom_node;
+  auto current_node = node_to_add;
+  NodeVal val_to_add = current_node->initial_value_;
+
+  while (current_node->info_.level != root_->info_.level) {
+    if (current_node->parent_id == 0) {
+      parent_node = openForInsertion(current_node->info_.level + 1);
+      if (parent_node) {
+        // Add the current_node to parent_node which still has more space for childs
+        current_node->parent_id = parent_node->info_.id;
+        parent_node->n_child++;
+        ConcordAssert(parent_node->n_child <= RVT_K);
+        parent_node->addValue(val_to_add);
+      } else {
+        // construct new internal RVT current_node
+        ConcordAssert(current_node->isMinChild() == true);
+        parent_node = make_shared<RVTNode>(current_node);
+        parent_node->addValue(val_to_add);
+        val_to_add += parent_node->initial_value_;
+        ConcordAssert(id_to_node_.insert({parent_node->info_.id, parent_node}).second == true);
+        rightmostRVTNode_[parent_node->info_.level] = parent_node;
+        current_node->parent_id = parent_node->info_.id;
+      }
+    } else {
+      parent_node = getParentNode(current_node);
+      ConcordAssert(parent_node != nullptr);
+      parent_node->addValue(val_to_add);
+    }
+    current_node = parent_node;
+  }
+
+  // no need to create new root as we have reached to root while updating value
+  if (current_node->info_.id == root_->info_.id) {
+    return;
+  }
+
+  // create new root
+  auto new_root = make_shared<RVTNode>(root_);
+  ConcordAssert(id_to_node_.insert({new_root->info_.id, new_root}).second == true);
+  current_node->parent_id = new_root->info_.id;
+  new_root->n_child++;
+  new_root->addValue(root_->current_value_);
+  new_root->addValue(current_node->current_value_);
+  ConcordAssert(new_root->n_child <= RVT_K);
+  setNewRoot(new_root);
+}
+
+void RangeValidationTree::removeAndUpdateInternalNodes(const RVTNodePtr& rvt_node, const NodeVal& value) {
+  ConcordAssert(rvt_node != nullptr);
+
+  // Loop 1
+  // Trim the tree from rvt_node to root
+  RVTNodePtr cur_node = rvt_node;
+  while (cur_node != root_) {
+    auto parent_node = getParentNode(cur_node);
+
+    // When rvt_node is removed, we need to update its parent
+    if (cur_node->n_child == 0) {
+      --parent_node->n_child;
+      if (parent_node->n_child > 0) {
+        auto level = cur_node->info_.level;
+        auto id = NodeInfo(level, cur_node->info_.rvb_index + RangeValidationTree::pow_uint(RVT_K, level)).id;
+        ConcordAssert(id_to_node_.find(id) != id_to_node_.end());
+        parent_node->min_child_id = id;
+      }
+      if (cur_node != rvt_node) {
+        id_to_node_.erase(cur_node->info_.id);
+        auto val_negative = cur_node->initial_value_;
+        val_negative.val_.SetNegative();
+        addValueToInternalNodes(getParentNode(cur_node), val_negative);
+        if ((leftmostRVTNode_[cur_node->info_.level] == cur_node) &&
+            (rightmostRVTNode_[cur_node->info_.level] == cur_node)) {
+          rightmostRVTNode_[cur_node->info_.level] = nullptr;
+          leftmostRVTNode_[cur_node->info_.level] = nullptr;
+        } else if (leftmostRVTNode_[cur_node->info_.level] == cur_node) {
+          leftmostRVTNode_[cur_node->info_.level] = getRVTNodeOfRightSibling(cur_node);
+        }
+      }
+    }
+    cur_node->substractValue(value);
+    cur_node = parent_node;
+  }
+  if (cur_node == root_) {
+    root_->substractValue(value);
+  }
+
+  // Loop 2
+  // Shrink the tree from root to bottom (level 1) . In theory, tree can end empty after this loop
+  while ((cur_node == root_) && (cur_node->n_child == 1) && (cur_node->info_.level > 1)) {
+    id_to_node_.erase(cur_node->info_.id);
+    ConcordAssertEQ(rightmostRVTNode_[cur_node->info_.level - 1], leftmostRVTNode_[cur_node->info_.level - 1])
+        rightmostRVTNode_[cur_node->info_.level] = nullptr;
+    leftmostRVTNode_[cur_node->info_.level] = nullptr;
+    cur_node = rightmostRVTNode_[cur_node->info_.level - 1];
+    setNewRoot(cur_node);
+  }
+}
+
+void RangeValidationTree::setNewRoot(const RVTNodePtr& new_root) {
+  if (!new_root) {
+    ConcordAssert(root_->info_.level == 1);
+    ConcordAssert(root_ != nullptr);
+    clear();
+    return;
+  }
+  if (root_) {
+    // replacing roots
+    int new_root_level = static_cast<int>(new_root->info_.level);
+    int old_root_level = static_cast<int>(root_->info_.level);
+    ConcordAssert(new_root_level != 0);
+    ConcordAssert(std::abs(new_root_level - old_root_level) == 1);
+    if (new_root_level > old_root_level) {
+      // replacing the root - tree grows 1 level
+      root_->parent_id = new_root->info_.id;
+    } else if (new_root_level < old_root_level) {
+      // replacing the root - tree shrinks 1 level
+      rightmostRVTNode_[root_->info_.level] = nullptr;
+      leftmostRVTNode_[root_->info_.level] = nullptr;
+    }
+  }
+  root_ = new_root;
+  root_->parent_id = 0;
+  rightmostRVTNode_[new_root->info_.level] = new_root;
+  leftmostRVTNode_[new_root->info_.level] = new_root;
+}
+
+inline RVTNodePtr RangeValidationTree::openForInsertion(uint64_t level) const {
+  if (rightmostRVTNode_[level] == nullptr) {
+    return nullptr;
+  }
+  auto& node = rightmostRVTNode_[level];
+  uint64_t min_child_actual_rvb_index = node->min_child_id & NodeInfo::kRvbIndexMask;
+  uint64_t max_child_possible_rvb_index = node->max_child_id & NodeInfo::kRvbIndexMask;
+  uint64_t max_child_actual_rvb_index =
+      min_child_actual_rvb_index + RangeValidationTree::pow_uint(RVT_K, node->info_.level - 1) * (node->n_child - 1);
+  return (max_child_actual_rvb_index < max_child_possible_rvb_index) ? node : nullptr;
+}
+
+inline RVTNodePtr RangeValidationTree::openForRemoval(uint64_t level) const { return leftmostRVTNode_[level]; }
+
+void RangeValidationTree::clear() noexcept {
+  // clear() reduced size to 0 and crashed while setting new root using operator []
+  for (uint8_t level = 0; level < NodeInfo::kMaxLevels; level++) {
+    rightmostRVTNode_[level] = nullptr;
+    leftmostRVTNode_[level] = nullptr;
+  }
+  id_to_node_.clear();
+  root_ = nullptr;
+  max_rvb_index_ = 0;
+  min_rvb_index_ = 0;
+}
+
+/////////////////////////////////// start of API //////////////////////////////////////////////
+
+void RangeValidationTree::addNode(const RVBId rvb_id, const char* data, size_t data_size) {
+  if (!isValidRvbId(rvb_id)) {
+    LOG_ERROR(logger_, "invalid input data" << KVLOG(rvb_id, data_size, fetch_range_size_));
+    ConcordAssert(false);
+  }
+  auto rvb_index = rvb_id / fetch_range_size_;
+  auto node = make_shared<RVBNode>(rvb_index, data, data_size);
+  if (max_rvb_index_ > 0) {
+    ConcordAssertEQ(max_rvb_index_ + 1, rvb_index);
+  }
+  addRVBNode(node);
+  max_rvb_index_ = rvb_index;
+  if (min_rvb_index_ == 0) {
+    min_rvb_index_ = rvb_index;
+  }
+  LOG_TRACE(logger_, KVLOG(rvb_id, max_rvb_index_));
+}
+
+void RangeValidationTree::removeNode(const RVBId rvb_id, const char* data, size_t data_size) {
+  ConcordAssert(root_ != nullptr);
+  if (!isValidRvbId(rvb_id)) {
+    LOG_ERROR(logger_, "invalid input data" << KVLOG(rvb_id, data_size, fetch_range_size_));
+    ConcordAssert(false);
+  }
+  auto rvb_index = rvb_id / fetch_range_size_;
+  auto node = make_shared<RVBNode>(rvb_index, data, data_size);
+  ConcordAssertEQ(min_rvb_index_, rvb_index);
+  removeRVBNode(node);
+  if (!root_) {
+    min_rvb_index_ = 0;
+    max_rvb_index_ = 0;
+  } else {
+    ++min_rvb_index_;
+  }
+  LOG_TRACE(logger_, KVLOG(rvb_id, min_rvb_index_));
+}
+
+std::ostringstream RangeValidationTree::getSerializedRvbData() const {
+  LOG_TRACE(logger_, "");
+  std::ostringstream os;
+  if (!root_) {
+    return os;
+  }
+  Serializable::serialize(os, magic_num_);
+  Serializable::serialize(os, version_num_);
+  Serializable::serialize(os, RVT_K);
+  Serializable::serialize(os, fetch_range_size_);
+  Serializable::serialize(os, value_size_);
+  Serializable::serialize(os, root_->info_.id);
+
+  Serializable::serialize(os, totalNodes());
+  for (auto& itr : id_to_node_) {
+    Serializable::serialize(os, itr.first);
+    auto serialized_node = itr.second->serialize();
+    Serializable::serialize(os, serialized_node.str().data(), serialized_node.str().size());
+  }
+
+  uint64_t null_node_id = 0;
+  auto max_levels = root_->info_.level;
+  for (uint64_t i = 0; i <= max_levels; i++) {
+    auto node = rightmostRVTNode_[i];
+    if (!node) {
+      Serializable::serialize(os, null_node_id);
+    } else {
+      Serializable::serialize(os, node->info_.id);
+    }
+  }
+  for (uint64_t i = 0; i <= max_levels; i++) {
+    auto node = leftmostRVTNode_[i];
+    if (!node) {
+      Serializable::serialize(os, null_node_id);
+    } else {
+      Serializable::serialize(os, node->info_.id);
+    }
+  }
+  LOG_TRACE(logger_, KVLOG(os.str().size()));
+  LOG_TRACE(logger_, "Nodes:" << totalNodes() << " root value:" << root_->current_value_.toString());
+  return os;
+}
+
+bool RangeValidationTree::setSerializedRvbData(std::istringstream& is) {
+  if (!(is.str().size())) {
+    LOG_ERROR(logger_, "invalid input");
+    return false;
+  }
+
+  clear();
+  RVTMetadata data;
+  Serializable::deserialize(is, data.magic_num);
+  Serializable::deserialize(is, data.version_num);
+  Serializable::deserialize(is, data.RVT_K);
+  Serializable::deserialize(is, data.fetch_range_size);
+  Serializable::deserialize(is, data.value_size);
+  Serializable::deserialize(is, data.root_node_id);
+  if ((data.magic_num != magic_num_) || (data.version_num != version_num_) || (data.RVT_K != RVT_K) ||
+      (data.fetch_range_size != fetch_range_size_) || (data.value_size != value_size_)) {
+    LOG_ERROR(logger_, "Failed to deserialize metadata");
+    clear();
+    return false;
+  }
+
+  // populate id_to_node_ map
+  Serializable::deserialize(is, data.total_nodes);
+  id_to_node_.reserve(data.total_nodes);
+  uint64_t min_rvb_index{std::numeric_limits<uint64_t>::max()}, max_rvb_index{0};
+  for (uint64_t i = 0; i < data.total_nodes; i++) {
+    auto node = RVTNode::createFromSerialized(is);
+    id_to_node_.emplace(node->info_.id, node);
+
+    if (node->info_.level == 1) {
+      // level 0 child IDs can be treated as rvb_indexes
+      if (node->min_child_id < min_rvb_index) {
+        min_rvb_index = node->min_child_id;
+      }
+      if ((node->min_child_id + node->n_child - 1) > max_rvb_index) {
+        max_rvb_index = (node->min_child_id + node->n_child - 1);
+      }
+    }
+  }
+  if (data.total_nodes > 0) {
+    ConcordAssertNE(max_rvb_index, 0);
+    ConcordAssertNE(min_rvb_index, std::numeric_limits<uint64_t>::max());
+    max_rvb_index_ = max_rvb_index;
+    min_rvb_index_ = min_rvb_index;
+  }
+
+  setNewRoot(id_to_node_[data.root_node_id]);
+
+  // populate rightmostRVTNode_
+  uint64_t node_id;
+  uint64_t null_node_id = 0;
+  auto max_levels = root_->info_.level;
+  for (size_t i = 0; i <= max_levels; i++) {
+    Serializable::deserialize(is, node_id);
+    if (node_id == null_node_id) {
+      rightmostRVTNode_[i] = nullptr;
+    } else {
+      rightmostRVTNode_[i] = id_to_node_[node_id];
+    }
+  }
+
+  // populate leftmostRVTNode_
+  for (size_t i = 0; i <= max_levels; i++) {
+    Serializable::deserialize(is, node_id);
+    if (node_id == null_node_id) {
+      leftmostRVTNode_[i] = nullptr;
+    } else {
+      leftmostRVTNode_[i] = id_to_node_[node_id];
+    }
+  }
+
+  is.peek();
+  if (not is.eof()) {
+    LOG_ERROR(logger_, "Still some data left to read from stream");
+    clear();
+    return false;
+  }
+
+  LOG_TRACE(logger_, "Nodes:" << totalNodes() << " root value:" << root_->current_value_.toString());
+  return true;
+}
+
+std::vector<RVBGroupId> RangeValidationTree::getRvbGroupIds(RVBId start_block_id, RVBId end_block_id) const {
+  LOG_TRACE(logger_, KVLOG(start_block_id, end_block_id));
+  std::vector<RVBGroupId> rvb_group_ids;
+  if ((start_block_id == 0) || (end_block_id == 0) || (start_block_id > end_block_id) ||
+      (!isValidRvbId(start_block_id)) || (!isValidRvbId(end_block_id))) {
+    LOG_ERROR(logger_, "invalid input data" << KVLOG(start_block_id, end_block_id));
+    return rvb_group_ids;
+  }
+
+  RVBIndex parent_rvb_index;
+  for (uint64_t rvb_id{start_block_id}; rvb_id <= end_block_id; rvb_id += fetch_range_size_) {
+    RVBIndex rvb_index = rvb_id / fetch_range_size_;
+    RVBIndex rvb_group_index = rvb_index / RVT_K;
+    if (rvb_index <= RVT_K) {
+      parent_rvb_index = 1;
+    } else if ((rvb_index % RVT_K) == 0) {
+      parent_rvb_index = (--rvb_group_index * RVT_K) + 1;
+    } else {
+      parent_rvb_index = (rvb_group_index * RVT_K) + 1;
+    }
+    RVBGroupId rvb_group_id = NodeInfo(RVTNode::kDefaultRVTLeafLevel, parent_rvb_index).id;
+    if (id_to_node_.find(rvb_group_id) == id_to_node_.end()) {
+      LOG_WARN(logger_, KVLOG(rvb_group_id, parent_rvb_index, start_block_id, end_block_id));
+      return rvb_group_ids;
+    }
+    if (rvb_group_ids.empty() || (rvb_group_ids.back() != rvb_group_id)) {
+      rvb_group_ids.push_back(rvb_group_id);
+    }
+  }
+  LOG_TRACE(logger_, KVLOG(rvb_group_ids.size()));
+  return rvb_group_ids;
+}
+
+std::vector<RVBId> RangeValidationTree::getRvbIds(RVBGroupId rvb_group_id) const {
+  LOG_TRACE(logger_, KVLOG(rvb_group_id));
+  std::vector<RVBId> rvb_ids;
+
+  if (!validateRVBGroupId(rvb_group_id)) {
+    LOG_ERROR(logger_, KVLOG(rvb_group_id));
+    return rvb_ids;
+  }
+  const auto iter = id_to_node_.find(rvb_group_id);
+  if (iter == id_to_node_.end()) {
+    LOG_WARN(logger_, KVLOG(rvb_group_id));
+    return rvb_ids;
+  }
+
+  auto min_child_id = iter->second->min_child_id;
+  for (size_t rvb_index{min_child_id}; rvb_index < min_child_id + iter->second->n_child; ++rvb_index) {
+    rvb_ids.push_back(rvb_index * fetch_range_size_);
+  }
+  return rvb_ids;
+}
+
+// validation can happen on partial RVGgroup as ST cycle might not fetch 256K blocks
+// Example:
+// FR = 256 rvbid = 256/1, 512/2, ...
+// RVT_K = 1024 * 256 = single RVGGroupId represents 256K blocks
+// received only 128K blocks from network
+std::string RangeValidationTree::getDirectParentValueStr(RVBId rvb_id) const {
+  std::string val;
+  if (!isValidRvbId(rvb_id)) {
+    return val;
+  }
+  LOG_TRACE(logger_, KVLOG(rvb_id));
+  RVBIndex rvb_index = rvb_id / fetch_range_size_;
+  RVBIndex parent_rvb_index;
+  if (rvb_index <= RVT_K) {
+    parent_rvb_index = 1;
+  } else if (rvb_index % RVT_K == 0) {
+    parent_rvb_index = rvb_index - RVT_K + 1;
+  } else {
+    parent_rvb_index = (rvb_index - (rvb_index % RVT_K)) + 1;
+  }
+  RVBGroupId parent_node_id = NodeInfo(RVTNode::kDefaultRVTLeafLevel, parent_rvb_index).id;
+  auto itr = id_to_node_.find(parent_node_id);
+  if (itr == id_to_node_.end()) {
+    LOG_WARN(logger_, KVLOG(parent_node_id, rvb_index, rvb_id));
+    return val;
+  }
+  val = itr->second->current_value_.toString();
+  LOG_TRACE(logger_, KVLOG(rvb_id, parent_node_id, val));
+  return val;
+}
+
+RVBId RangeValidationTree::getMinRvbId() const { return (min_rvb_index_ * fetch_range_size_); }
+
+RVBId RangeValidationTree::getMaxRvbId() const {
+  if (max_rvb_index_ == 0) {
+    ConcordAssertEQ(totalNodes(), 0);
+    ConcordAssertEQ(root_, nullptr);
+    return 0;
+  }
+  return max_rvb_index_ * fetch_range_size_;
+}
+
+//////////////////////////////////// End of API ////////////////////////////////////////////////
+
+}  // namespace bftEngine::bcst::impl

--- a/bftengine/src/bcstatetransfer/RangeValidationTree.hpp
+++ b/bftengine/src/bcstatetransfer/RangeValidationTree.hpp
@@ -1,0 +1,295 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#pragma once
+
+#include <iostream>
+#include <vector>
+#include <memory>
+#include <unordered_map>
+#include <string>
+#include <cmath>
+#include <limits>
+
+#include <cryptopp/integer.h>
+
+#include "STDigest.hpp"
+#include "Serializable.h"
+#include "Logger.hpp"
+
+namespace bftEngine::bcst::impl {
+
+using RVBGroupId = uint64_t;
+using RVBId = uint64_t;
+using RVBIndex = uint64_t;
+
+// A Range Validation Tree (RVT)
+//
+// RVT is used to confirm that blocks collected from any single source (part of consensus network) during State Transfer
+// are valid and true. This is done by validating digest of certain blocks at frequent interval (RVB) against the tree.
+// RVT would be updated during checkpointing and also in the context of pruning. New nodes would be added to RVT during
+// checkpointing where as existing nodes would be deleted when pruning on old blocks begins.
+// Comment: this data strucutre is easy to be used to validate any type of data, not only block digests.
+//
+// Terms used throughout code -
+// 1. RVT_K = Maximum number of children any node can have
+// 2. Fetch range = Not all blocks will be validated. Only max block from given fetch range will be validated.
+// 3. RVB Id = Any block id in multiple of fetch range size
+// 4. RVB Index = RVBId / fetch range size
+// 5. RVB GroupIndex = Minimum of RVBIndex of all childrens
+//
+// Things to remember -
+// 1. Tree does not store RVB nodes.
+// 2. Only blocks at specific interval are validated to improve replica recovery time.
+// 3. Each node in tree is represented having type as NodeInfo.
+// 4. NodeVal is stored in form of CryptoPP::Integer.
+//
+// Implemention notes -
+// 1. APIs do not throw exception
+// 2. Thread safety is delegated to caller (e.g. RVBManager)
+// 3. Bad inputs values are asserted
+//
+
+class RangeValidationTree {
+  // The next friend declerations are used strictly for testing
+  friend class BcStTestDelegator;
+
+  using NodeVal_t = CryptoPP::Integer;
+
+ public:
+  /////////////////////////// API /////////////////////////////////////
+  RangeValidationTree(const logging::Logger& logger, uint32_t RVT_K, uint32_t fetch_range_size, size_t value_size = 32);
+  ~RangeValidationTree() = default;
+  RangeValidationTree(const RangeValidationTree&) = delete;
+  RangeValidationTree& operator=(RangeValidationTree&) = delete;
+
+  // All API deals with only range validation block (RVB) ids.
+  // In case tree structure found inconsistent internally, it may assert.
+  void addNode(const RVBId id, const char* data, size_t data_size);
+  void removeNode(const RVBId id, const char* data, size_t data_size);
+  // Return complete tree along with metadata in serialized format
+  // In case of failure can assert
+  std::ostringstream getSerializedRvbData() const;
+  // Initialize metadata & build tree by deserializing input stream
+  // If function fails, tree reset to null and returns false.
+  // In case of failure can assert
+  bool setSerializedRvbData(std::istringstream& iss);
+
+  // Returns RVB group ids in ascending order. In case of failure, returns empty vector.
+  std::vector<RVBGroupId> getRvbGroupIds(RVBId start_block_id, RVBId end_block_id) const;
+  // Returns all actual childs in ascending order. In case of failure, returns empty vector.
+  std::vector<RVBId> getRvbIds(RVBGroupId id) const;
+  // Returns value of direct parent of RVB. In case of failure, returns empty string with size zero.
+  std::string getDirectParentValueStr(RVBId rvb_id) const;
+
+  // Return the min RVB ID in the tree. Return 0 if tree is empty.
+  RVBId getMinRvbId() const;
+  // Return the max RVB ID in the tree. Return 0 if tree is empty.
+  RVBId getMaxRvbId() const;
+  bool empty() const { return (id_to_node_.size() == 0) ? true : false; }
+  const std::string getRootCurrentValueStr() const { return root_ ? root_->current_value_.toString() : ""; }
+  // Clear all data structures
+  void clear() noexcept;
+
+  // Log tree only if total elements are less than 10K. In case of failure can assert.
+  void printToLog(bool only_node_id) const noexcept;
+  // Validate structure and values inside tree. In case of failure can assert.
+  bool validate() const noexcept;
+
+ public:
+  struct NodeVal {
+    static NodeVal_t kNodeValueMax_;
+    static NodeVal_t kNodeValueModulo_;
+    static NodeVal_t calcMaxValue(size_t val_size);
+    static NodeVal_t calcModulo(size_t val_size);
+
+    NodeVal(const std::shared_ptr<char[]>&& val, size_t size);
+    NodeVal(const char* val_ptr, size_t size);
+    NodeVal(const NodeVal_t* val);
+    NodeVal(const NodeVal_t& val);
+    NodeVal(const NodeVal_t&& val);
+    NodeVal();
+
+    NodeVal& operator+=(const NodeVal& other);
+    NodeVal& operator-=(const NodeVal& other);
+    bool operator!=(const NodeVal& other);
+    bool operator==(const NodeVal& other);
+
+    const NodeVal_t& getMaxVal() const { return kNodeValueMax_; }
+    const NodeVal_t& getVal() const { return val_; }
+    std::string toString() const noexcept;
+    std::string getDecoded() const noexcept;
+    size_t getSize() const { return val_.MinEncodedSize(); }
+
+    static constexpr size_t kDigestContextOutputSize = BLOCK_DIGEST_SIZE;
+    static constexpr std::array<char, kDigestContextOutputSize> initialValueZeroData{};
+
+    NodeVal_t val_;
+  };
+
+  struct NodeInfo {
+    NodeInfo(uint64_t node_id)
+        : level(node_id >> kNIDBitsPerRVBIndex),
+          rvb_index(node_id & kRvbIndexMask),
+          id((static_cast<uint64_t>(level) << kNIDBitsPerRVBIndex) | rvb_index) {}
+    NodeInfo(uint8_t l, uint64_t index)
+        : level(l),
+          rvb_index(index & kRvbIndexMask),
+          id((static_cast<uint64_t>(level) << kNIDBitsPerRVBIndex) | rvb_index) {}
+    NodeInfo() = delete;
+
+    bool operator<(NodeInfo& other) const noexcept {
+      return ((level <= other.level) || (rvb_index < other.rvb_index)) ? true : false;
+    }
+    bool operator!=(NodeInfo& other) const noexcept {
+      return ((level != other.level) || (rvb_index != other.rvb_index)) ? true : false;
+    }
+    std::string toString() const noexcept;
+
+    static constexpr size_t kNIDBitsPerLevel = 8;
+    static constexpr size_t kNIDBitsPerRVBIndex = ((sizeof(uint64_t) * 8) - kNIDBitsPerLevel);
+    static constexpr size_t kMaxLevels = ((0x1 << kNIDBitsPerLevel) - 1);
+    static constexpr uint64_t kRvbIdMask = (kMaxLevels) << kNIDBitsPerRVBIndex;
+    static constexpr uint64_t kRvbIndexMask = std::numeric_limits<uint64_t>::max() & (~kRvbIdMask);
+
+    // TODO - Helper functions to cast between id, level, rvb_index
+    // node location in the tree
+    const uint64_t level : kNIDBitsPerLevel;
+    const uint64_t rvb_index : kNIDBitsPerRVBIndex;
+
+    // node ID
+    const uint64_t id;
+  };
+
+  // Each node, even 0 level nodes, holds a current value and an initial value.
+  //
+  // The node is constructed with an initial value:
+  // 1) Initial value of a level 0 nodes is a function of its ID and an external (user input) message of size N.
+  // 2) Initial value of any other value is a function of its ID and a zero message of size N.
+  //
+  // Initially, both current value and initial values are equal.
+  // The tree is maintained in such way that the current value (CV) and the (IV) should have the next equation always
+  // true for any level I>0 node in the tree: CV = IV +  Sum(IV of all nodes connected directly or indirectly to that
+  // node in lower levels) and also CV - IV = Sum(CV of all direct connected children)
+  struct RVBNode {
+    RVBNode(uint64_t rvb_index, const char* data, size_t data_size);
+    RVBNode(uint8_t level, uint64_t rvb_index);
+    RVBNode(uint64_t node_id, char* val, size_t size);
+
+    bool isMinChild() { return info_.rvb_index % RVT_K == 1; }
+    bool isMaxChild() { return info_.rvb_index % RVT_K == 0; }
+    void logInfoVal(const std::string& prefix = "");
+    const std::shared_ptr<char[]> computeNodeInitialValue(NodeInfo& node_id, const char* data, size_t data_size);
+
+    static constexpr uint8_t kDefaultRVBLeafLevel{0};
+    NodeInfo info_;
+    NodeVal current_value_;
+    static uint32_t RVT_K;
+  };
+
+ public:
+#pragma pack(push, 1)
+  struct RVTMetadata {
+    uint64_t magic_num;
+    uint8_t version_num;
+    uint32_t RVT_K;
+    uint32_t fetch_range_size;
+    size_t value_size;
+    uint64_t total_nodes;
+    uint64_t root_node_id;
+
+    static void staticAssert() noexcept;
+  };
+#pragma pack(pop)
+
+  struct SerializedRVTNode {
+    uint64_t id;
+    size_t current_value_encoded_size;
+    uint16_t n_child;
+    uint64_t min_child_id;
+    uint64_t max_child_id;
+    uint64_t parent_id;
+
+    static void staticAssert() noexcept;
+  };
+
+  struct RVTNode;
+  using RVBNodePtr = std::shared_ptr<RVBNode>;
+  using RVTNodePtr = std::shared_ptr<RVTNode>;
+  struct RVTNode : public RVBNode {
+    RVTNode(const RVBNodePtr& node);
+    RVTNode(const RVTNodePtr& node);
+    RVTNode(SerializedRVTNode& node, char* cur_val_ptr, size_t cur_value_size);
+    static RVTNodePtr createFromSerialized(std::istringstream& is);
+
+    void addValue(const NodeVal& nvalue);
+    void substractValue(const NodeVal& nvalue);
+    std::ostringstream serialize() const;
+
+    static constexpr uint8_t kDefaultRVTLeafLevel = 1;
+    uint16_t n_child{0};
+    uint64_t min_child_id{0};      // Minimal actual child id
+    uint64_t max_child_id{0};      // Maximal possible child id. The max actual is min_child_id + n_child.
+    uint64_t parent_id{0};         // for root - will be 0
+    const NodeVal initial_value_;  // We need to keep this value to validate node's current value
+  };
+
+ public:
+  // validation functions
+  static uint64_t pow_uint(uint64_t base, uint64_t exp) noexcept;
+  size_t totalNodes() const { return id_to_node_.size(); }
+  size_t totalLevels() const { return root_ ? root_->info_.level : 0; }
+
+ protected:
+  bool isValidRvbId(const RVBId& block_id) const noexcept;
+  bool validateRVBGroupId(const RVBGroupId rvb_group_id) const;
+  bool validateTreeStructure() const noexcept;
+  bool validateTreeValues() const noexcept;
+
+  // Helper functions
+  RVTNodePtr getRVTNodeOfLeftSibling(const RVTNodePtr& node) const;
+  RVTNodePtr getRVTNodeOfRightSibling(const RVTNodePtr& node) const;
+  RVTNodePtr getParentNode(const RVTNodePtr& node) const noexcept;
+  RVTNodePtr getLeftMostChildNode(const RVTNodePtr& node) const noexcept;
+
+  // tree internal manipulation functions
+  void addRVBNode(const RVBNodePtr& node);
+  void addInternalNode(const RVTNodePtr& node);
+  void removeRVBNode(const RVBNodePtr& node);
+  void addValueToInternalNodes(const RVTNodePtr& bottom_node, const NodeVal& value);
+  void removeAndUpdateInternalNodes(const RVTNodePtr& rvt_node, const NodeVal& value);
+  void setNewRoot(const RVTNodePtr& new_root);
+  RVTNodePtr openForInsertion(uint64_t level) const;
+  RVTNodePtr openForRemoval(uint64_t level) const;
+
+ protected:
+  static constexpr size_t kMaxNodesToPrint{10000};
+  // vector index represents level in tree
+  // level 0 represents RVB node so it would always hold 0x0
+  std::array<RVTNodePtr, NodeInfo::kMaxLevels> rightmostRVTNode_;
+  std::array<RVTNodePtr, NodeInfo::kMaxLevels> leftmostRVTNode_;
+  std::unordered_map<uint64_t, RVTNodePtr> id_to_node_;
+  RVTNodePtr root_{nullptr};
+  uint64_t max_rvb_index_{0};  // RVB index is (RVB ID / fetch range size). This is the maximal index in the tree.
+  uint64_t min_rvb_index_{0};  // RVB index is (RVB ID / fetch range size). This is the minimal index in the tree.
+
+  const logging::Logger& logger_;
+  const uint32_t RVT_K{0};
+  const uint32_t fetch_range_size_{0};
+  const size_t value_size_{0};
+  static constexpr uint8_t CHECKPOINT_PERSISTENCY_VERSION{1};
+  static constexpr uint8_t version_num_{CHECKPOINT_PERSISTENCY_VERSION};
+  static constexpr uint64_t magic_num_{0x1122334455667788};
+};
+
+}  // namespace bftEngine::bcst::impl

--- a/bftengine/tests/bcstatetransfer/CMakeLists.txt
+++ b/bftengine/tests/bcstatetransfer/CMakeLists.txt
@@ -24,4 +24,4 @@ target_include_directories(source_selector_test PRIVATE ${bftengine_SOURCE_DIR}/
 add_executable(RVT_test RVT_test.cpp)
 add_test(RVT_test RVT_test)
 target_link_libraries(RVT_test GTest::Main ${CRYPTOPP_LIBRARIES} corebft)
-target_include_directories(RVT_test PRIVATE ${CRYPTOPP_INCLUDE_DIRS})
+target_include_directories(RVT_test PRIVATE ${CRYPTOPP_INCLUDE_DIRS} PRIVATE ${bftengine_SOURCE_DIR}/src/bcstatetransfer)

--- a/bftengine/tests/bcstatetransfer/RVT_test.cpp
+++ b/bftengine/tests/bcstatetransfer/RVT_test.cpp
@@ -15,16 +15,28 @@
 #include <string>
 #include <random>
 #include <vector>
-#include <cryptopp/integer.h>
+#include <string>
+#include <cmath>
 
+#include <cryptopp/integer.h>
 #include "gtest/gtest.h"
 
+#include "RangeValidationTree.hpp"
 #include "Logger.hpp"
+#include "kv_types.hpp"
 
-#define HASH_SIZE 256
+#define HASH_SIZE 32
 
 using namespace std;
 using namespace CryptoPP;
+using namespace concord::kvbc;
+
+static constexpr uint32_t RVT_K = 3;
+
+namespace bftEngine::bcst::impl {
+
+using NodeInfo = RangeValidationTree::NodeInfo;
+using RVTNode = RangeValidationTree::RVTNode;
 
 static std::string randomString(size_t length) {
   static auto& chrs = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -38,6 +50,16 @@ static std::string randomString(size_t length) {
   return s;
 }
 
+static uint32_t randomNum(uint32_t min = 3, uint32_t max = UINT32_MAX / 1000, uint32_t in_multiple_of = 0) {
+  std::mt19937 rg{std::random_device{}()};
+  std::uniform_int_distribution<std::string::size_type> pick(min, max);
+  auto num = pick(rg);
+  if (in_multiple_of) {
+    return (num - (num % in_multiple_of));
+  }
+  return num;
+}
+
 struct InputValues {
   InputValues(const string& l1, const string& l2, const string& p)
       : leaf1(l1.c_str()), leaf2(l2.c_str()), parent(p.c_str()) {}
@@ -46,10 +68,31 @@ struct InputValues {
   Integer parent;  // mod by parent val (shld size be any different than leaf), shld be 256 byte?
 };
 
+class BcStTestDelegator {
+ public:
+  BcStTestDelegator(RangeValidationTree& rvt) : rvt_(rvt){};
+  BcStTestDelegator() = delete;
+  bool validateRVBGroupId(const RVBGroupId rvb_group_id) const { return rvt_.validateRVBGroupId(rvb_group_id); }
+
+ private:
+  RangeValidationTree& rvt_;
+};
+
 class RVTTest : public ::testing::Test {
  public:
+  void init(RangeValidationTree& rvt) {
+    delegator_ = std::make_unique<BcStTestDelegator>(rvt);
+    logging::Logger::getInstance("concord.bft").setLogLevel(log4cplus::ERROR_LOG_LEVEL);
+    logging::Logger::getInstance("concord.bft.st.dst").setLogLevel(log4cplus::ERROR_LOG_LEVEL);
+    logging::Logger::getInstance("concord.bft.st.src").setLogLevel(log4cplus::ERROR_LOG_LEVEL);
+    logging::Logger::getInstance("concord.util.handoff").setLogLevel(log4cplus::ERROR_LOG_LEVEL);
+    logging::Logger::getInstance("concord.bft.st.rvb").setLogLevel(log4cplus::ERROR_LOG_LEVEL);
+  }
   InputValues values_{randomString(HASH_SIZE), randomString(HASH_SIZE), randomString(HASH_SIZE)};
+  std::shared_ptr<BcStTestDelegator> delegator_;
 };
+
+/////////////////////// starting of maths properties validation test for cryptoPP::Integer class  /////////////////////
 
 TEST_F(RVTTest, basicAdditionSubtraction) {
   auto a = values_.leaf1;
@@ -90,13 +133,13 @@ INSTANTIATE_TEST_CASE_P(
 
 class RVTTestParamFixture : public RVTTest, public testing::WithParamInterface<std::string> {};
 TEST_P(RVTTestParamFixture, validateRawValue) {
-  auto str = GetParam();
-  Integer input(static_cast<CryptoPP::byte*>((unsigned char*)str.c_str()), str.size());
+  std::string str = GetParam();
+  Integer input(reinterpret_cast<unsigned char*>(str.data()), str.size());
 
   ASSERT_EQ(input.MinEncodedSize(), str.size());
   // Encode to string doesn't work
   vector<char> enc_input(input.MinEncodedSize());
-  input.Encode((CryptoPP::byte*)enc_input.data(), enc_input.size());
+  input.Encode(reinterpret_cast<CryptoPP::byte*>(enc_input.data()), enc_input.size());
   ostringstream oss_en;
   for (auto& c : enc_input) {
     oss_en << c;
@@ -110,7 +153,277 @@ INSTANTIATE_TEST_CASE_P(validateRawValue,
                                           randomString(HASH_SIZE),
                                           randomString(HASH_SIZE)), );
 
+/////////////////// ending  of maths properties validation test for cryptoPP::Integer class ///////////////////////
+
+TEST_F(RVTTest, constructTreeWithSingleFirstNode) {
+  static constexpr uint32_t fetch_range_size = 4;
+  RangeValidationTree rvt(logging::getLogger("concord.bft.st.rvt"), RVT_K, fetch_range_size);
+  for (auto i = fetch_range_size; i <= fetch_range_size; i = i + fetch_range_size) {
+    STDigest digest(std::to_string(i).c_str());
+    rvt.addNode(i, digest.get(), BLOCK_DIGEST_SIZE);
+    ASSERT_TRUE(rvt.validate());
+  }
+  ASSERT_EQ(rvt.totalNodes(), 1);
+  ASSERT_EQ(rvt.empty(), false);
+  ASSERT_EQ(rvt.totalLevels(), 1);
+}
+
+TEST_F(RVTTest, constructTreeWithSingleMiddleNode) {
+  static constexpr uint32_t fetch_range_size = 4;
+  RangeValidationTree rvt(logging::getLogger("concord.bft.st.rvt"), RVT_K, fetch_range_size);
+  for (auto i = fetch_range_size * 2; i <= fetch_range_size * 2; i = i + fetch_range_size) {
+    STDigest digest(std::to_string(i).c_str());
+    rvt.addNode(i, digest.get(), BLOCK_DIGEST_SIZE);
+    ASSERT_TRUE(rvt.validate());
+  }
+  ASSERT_EQ(rvt.totalNodes(), 1);
+  ASSERT_EQ(rvt.totalLevels(), 1);
+}
+
+TEST_F(RVTTest, constructTreeWithSingleLastNode) {
+  static constexpr uint32_t fetch_range_size = 4;
+  RangeValidationTree rvt(logging::getLogger("concord.bft.st.rvt"), RVT_K, fetch_range_size);
+  for (auto i = fetch_range_size * RVT_K; i <= fetch_range_size * RVT_K; i = i + fetch_range_size) {
+    STDigest digest(std::to_string(i).c_str());
+    rvt.addNode(i, digest.get(), BLOCK_DIGEST_SIZE);
+    ASSERT_TRUE(rvt.validate());
+  }
+  ConcordAssertEQ(rvt.totalNodes(), 1);
+  ConcordAssertEQ(rvt.totalLevels(), 1);
+}
+
+TEST_F(RVTTest, constructTreeWithTwoNodes) {
+  static constexpr uint32_t fetch_range_size = 4;
+  RangeValidationTree rvt(logging::getLogger("concord.bft.st.rvt"), RVT_K, fetch_range_size);
+  for (auto i = fetch_range_size; i <= fetch_range_size * RVT_K + fetch_range_size; i = i + fetch_range_size) {
+    STDigest digest(std::to_string(i).c_str());
+    rvt.addNode(i, digest.get(), BLOCK_DIGEST_SIZE);
+    ASSERT_TRUE(rvt.validate());
+  }
+  rvt.printToLog(false);
+  ConcordAssertEQ(rvt.totalLevels(), 2);
+  ConcordAssertEQ(rvt.totalNodes(), 3);
+}
+
+TEST_F(RVTTest, TreeNodeRemovalBasic) {
+  static constexpr uint32_t fetch_range_size = 4;
+  RangeValidationTree rvt(logging::getLogger("concord.bft.st.rvt"), RVT_K, fetch_range_size);
+  for (auto i = fetch_range_size; i <= fetch_range_size * RVT_K + fetch_range_size; i = i + fetch_range_size) {
+    STDigest digest(std::to_string(i).c_str());
+    rvt.addNode(i, digest.get(), BLOCK_DIGEST_SIZE);
+    ASSERT_TRUE(rvt.validate());
+  }
+  for (auto i = fetch_range_size; i <= fetch_range_size * RVT_K + fetch_range_size; i = i + fetch_range_size) {
+    STDigest digest(std::to_string(i).c_str());
+    rvt.removeNode(i, digest.get(), BLOCK_DIGEST_SIZE);
+    ASSERT_TRUE(rvt.validate());
+  }
+  ASSERT_EQ(rvt.totalNodes(), 0);
+  ASSERT_EQ(rvt.empty(), true);
+}
+
+class RVTTestserializeDeserializeFixture : public RVTTest,
+                                           public testing::WithParamInterface<std::pair<uint32_t, uint32_t>> {};
+TEST_P(RVTTestserializeDeserializeFixture, serializeDeserialize) {
+  auto inputs = GetParam();
+  uint32_t RVT_K = inputs.first;
+  const uint32_t fetch_range_size = inputs.second;
+  RangeValidationTree rvt(logging::getLogger("concord.bft.st.rvt"), RVT_K, fetch_range_size);
+  size_t random_num_of_nodes_added = randomNum(1, 1000 * RVT_K);
+
+  std::cout << KVLOG(random_num_of_nodes_added, RVT_K, fetch_range_size) << std::endl;
+  for (auto i = fetch_range_size; i <= fetch_range_size * random_num_of_nodes_added; i = i + fetch_range_size) {
+    STDigest digest(std::to_string(i).c_str());
+    rvt.addNode(i, digest.get(), BLOCK_DIGEST_SIZE);
+    ASSERT_TRUE(rvt.validate());
+  }
+  // TODO - move this into ctor on product in RVTNode
+  auto root_hash = rvt.getRootCurrentValueStr();
+  auto total_levels = rvt.totalLevels();
+  auto total_nodes = rvt.totalNodes();
+
+  std::ostringstream oss;
+  oss = rvt.getSerializedRvbData();
+  std::istringstream iss(oss.str());
+  rvt.setSerializedRvbData(iss);
+
+  ASSERT_EQ(root_hash, rvt.getRootCurrentValueStr());
+  ASSERT_EQ(total_nodes, rvt.totalNodes());
+  ASSERT_EQ(total_levels, rvt.totalLevels());
+}
+INSTANTIATE_TEST_CASE_P(serializeDeserialize,
+                        RVTTestserializeDeserializeFixture,
+                        ::testing::Values(std::make_pair(randomNum(3, 10), randomNum(4, 20)),
+                                          std::make_pair(randomNum(3, 10), randomNum(4, 20)),
+                                          std::make_pair(randomNum(3, 10), randomNum(4, 20))), );
+
+class RVTTestRandomFRSAndRVT_KFixture : public RVTTest,
+                                        public testing::WithParamInterface<std::pair<uint32_t, uint32_t>> {};
+TEST_P(RVTTestRandomFRSAndRVT_KFixture, validateRandomFRSAndRVT_K) {
+  auto inputs = GetParam();
+  uint32_t RVT_K = inputs.first;
+  const uint32_t fetch_range_size = inputs.second;
+  RVT_K = 1024;
+  RangeValidationTree rvt(logging::getLogger("concord.bft.st.rvt"), RVT_K, fetch_range_size);
+  uint32_t n_nodes = fetch_range_size * 1024 * 10;
+  for (uint32_t i = fetch_range_size; i <= n_nodes; i = i + fetch_range_size) {
+    STDigest digest(std::to_string(i).c_str());
+    rvt.addNode(i, digest.get(), BLOCK_DIGEST_SIZE);
+    ASSERT_TRUE(rvt.validate());
+  }
+  // TODO Find formula to validate total nodes
+  auto min_rvb = 1;
+  auto n_rvb_groups = (((n_nodes / fetch_range_size) - min_rvb) / (RVT_K)) + 1;
+  auto max_level_by_formula = ceil(log(n_rvb_groups) / log(RVT_K)) + 1;
+  auto max_level_from_tree = rvt.totalLevels();
+  ASSERT_EQ(max_level_by_formula, max_level_from_tree);
+}
+INSTANTIATE_TEST_CASE_P(validateRandomFRSAndRVT_K,
+                        RVTTestRandomFRSAndRVT_KFixture,
+                        ::testing::Values(std::make_pair(randomNum(3, 10), randomNum(4, 20)),
+                                          std::make_pair(randomNum(3, 10), randomNum(4, 20)),
+                                          std::make_pair(randomNum(3, 10), randomNum(4, 20))), );
+
+class RVTTestvalidateTreeFixture : public RVTTest, public testing::WithParamInterface<std::pair<uint32_t, uint32_t>> {};
+TEST_P(RVTTestvalidateTreeFixture, validateTree) {
+  auto inputs = GetParam();
+  uint32_t RVT_K = inputs.first;
+  uint32_t fetch_range_size = inputs.second;
+  uint32_t n_nodes = fetch_range_size * randomNum(10, 100);
+  std::cout << KVLOG(fetch_range_size, n_nodes, RVT_K) << std::endl;
+
+  RangeValidationTree rvt(logging::getLogger("concord.bft.st.rvt"), RVT_K, fetch_range_size);
+  auto addNode = [&](uint64_t rvb_id) {
+    // std::cout << "add:" << KVLOG(rvb_id) << std::endl;
+    STDigest digest(std::to_string(rvb_id).c_str());
+    rvt.addNode(rvb_id, digest.get(), BLOCK_DIGEST_SIZE);
+    ASSERT_TRUE(rvt.validate());
+  };
+
+  // auto removeNode = [&](uint64_t rvb_id) {
+  // std::cout << "remove:" << KVLOG(rvb_id) << std::endl;
+  //  STDigest digest(std::to_string(rvb_id).c_str());
+  //  rvt.removeNode(rvb_id, digest);
+  // };
+
+  // add, remove nodes randomly.
+  for (uint32_t i = fetch_range_size; i <= n_nodes; i = i + fetch_range_size) {
+    addNode(rvt.getMaxRvbId() + fetch_range_size);
+    // TODO Enable and fix issue
+    //
+    // auto num = randomNum(1, 2);
+    // ((num % 2) || rvt.empty()) ? addNode(rvt.getMaxRvbId() + fetch_range_size)
+    //                            : removeNode(rvt.getMinRvbId());
+    ASSERT_TRUE(rvt.validate());
+  }
+}
+INSTANTIATE_TEST_CASE_P(validateTree,
+                        RVTTestvalidateTreeFixture,
+                        ::testing::Values(std::make_pair(randomNum(3, 10), randomNum(4, 20)),
+                                          std::make_pair(randomNum(3, 10), randomNum(4, 20)),
+                                          std::make_pair(randomNum(3, 10), randomNum(4, 20))), );
+
+// TODO Need to be improved to have random RVT_K and validation logic
+TEST_F(RVTTest, validateRvbGroupIds) {
+  uint32_t RVT_K = 4;
+  const uint32_t fetch_range_size = 5;
+  RangeValidationTree rvt(logging::getLogger("concord.bft.st.rvt"), RVT_K, fetch_range_size);
+  init(rvt);
+
+  for (auto i = fetch_range_size; i <= fetch_range_size * RVT_K * 2 + fetch_range_size; i = i + fetch_range_size) {
+    // TODO genesis block to have 0 digest?
+    // if (i == fetch_range_size) {
+    //  rvt.addNode(i, STDigest{});
+    // } else {
+    STDigest digest(std::to_string(i).c_str());
+    rvt.addNode(i, digest.get(), BLOCK_DIGEST_SIZE);
+    ASSERT_TRUE(rvt.validate());
+  }
+
+  // Both blocks fall under same parent rvb-group-id
+  std::vector<RVBGroupId> rvb_group_ids;
+  rvb_group_ids = rvt.getRvbGroupIds(5, 5);
+  ASSERT_EQ(rvb_group_ids.size(), 1);
+  auto hash_val_1 = rvt.getDirectParentValueStr(randomNum(5, 10, 5));
+  auto hash_val_2 = rvt.getDirectParentValueStr(randomNum(15, 20, 5));
+  ASSERT_EQ(hash_val_1, hash_val_2);
+
+  // Blocks span across multiple rvb-group-ids
+  rvb_group_ids = rvt.getRvbGroupIds(5, 45);
+  ASSERT_EQ(rvb_group_ids.size(), 3);
+  ASSERT_NE(rvt.getDirectParentValueStr(randomNum(5, 20, 5)), rvt.getDirectParentValueStr(randomNum(25, 40, 5)));
+  ASSERT_NE(rvt.getDirectParentValueStr(randomNum(5, 20, 5)), rvt.getDirectParentValueStr(45));
+  ASSERT_NE(rvt.getDirectParentValueStr(randomNum(25, 40, 5)), rvt.getDirectParentValueStr(45));
+
+  std::vector<BlockId> rvb_block_ids = rvt.getRvbIds(rvb_group_ids[0]);
+  if (not delegator_->validateRVBGroupId(rvb_group_ids[0])) {
+    ASSERT_EQ(rvb_block_ids.size(), 0);
+  } else {
+    ASSERT_EQ(rvb_block_ids.size(), 4);
+  }
+}
+
+class RVTTestFixture
+    : public RVTTest,
+      public testing::WithParamInterface<tuple<uint64_t, uint64_t, tuple<vector<size_t>, vector<size_t>>>> {};
+
+TEST_P(RVTTestFixture, simpleAddRemoveWithRootValidation) {
+  uint64_t test_progress{0};
+  uint64_t fetch_range_size = 4;
+  uint64_t RVT_K = get<0>(GetParam());
+  auto rvt_value_size = get<1>(GetParam());
+  RangeValidationTree rvt(logging::getLogger("concord.bft.st.rvt"), RVT_K, fetch_range_size, rvt_value_size);
+  size_t add_i{1}, rem_i{1};
+  auto scenario = get<2>(GetParam());
+  auto add_nodes_itertion_size = get<0>(scenario);
+  auto remove_nodes_itertion_size = get<1>(scenario);
+
+  std::cout << "Params:" << KVLOG(RVT_K, rvt_value_size) << endl;
+
+  ASSERT_EQ(add_nodes_itertion_size.size(), remove_nodes_itertion_size.size());
+  for (size_t i{}; i < add_nodes_itertion_size.size(); ++i) {
+    for (; add_i < add_nodes_itertion_size[i]; ++add_i) {
+      // std::cout << "add:" << KVLOG(add_i * fetch_range_size) << std::endl;
+      string str{{std::to_string(add_i * fetch_range_size)}};
+      rvt.addNode(add_i * fetch_range_size, str.data(), str.size());
+      ASSERT_TRUE(rvt.validate());
+      ++test_progress;
+      if (test_progress % 100000 == 0) {
+        std::cout << "Iteration # " << test_progress << std::endl;
+      }
+    }
+    for (; rem_i < remove_nodes_itertion_size[i]; ++rem_i) {
+      // std::cout << "remove:" << KVLOG(rem_i * fetch_range_size) << std::endl;
+      string str{{std::to_string(rem_i * fetch_range_size)}};
+      rvt.removeNode(rem_i * fetch_range_size, str.data(), str.size());
+      ASSERT_TRUE(rvt.validate());
+      ++test_progress;
+      if (test_progress % 100000 == 0) {
+        std::cout << "Iteration # " << test_progress << std::endl;
+      }
+    }
+  }
+  ASSERT_TRUE(rvt.empty());
+}
+
+std::vector<uint64_t> RVT_Ks = {4, 1024};
+std::vector<uint64_t> value_sizes = {1, 32};
+vector<std::tuple<std::vector<size_t>, std::vector<size_t>>> scenarios = {
+    {{1000, 500, 500, 400}, {1000, 300, 600, 500}}, {{1024 * 5}, {1024 * 5}}};
+
+INSTANTIATE_TEST_CASE_P(RVTTest,
+                        RVTTestFixture,
+                        ::testing::Combine(::testing::ValuesIn(RVT_Ks),
+                                           ::testing::ValuesIn(value_sizes),
+                                           ::testing::ValuesIn(scenarios)), );
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
+
+// TODO
+// validate concurrent addition & removal of nodes from RVT
+// validate hash val against addition & removal of RVB nodes
+
+}  // namespace bftEngine::bcst::impl


### PR DESCRIPTION
RVT is a lightweight data structure used to maintain current state of
blockchain on all active replicas. Whenever lagging replica tries to
recover, RVT would be used to validate blocks (at range) fetched from
last_reachable_block+1 till max block in latest checkpoint.

Blocks at regular intervals would be represented as leaf node in RVT.
Internal nodes would get created based on RVT_K (#child each node can
have).

RVT would be updated in below scenarios -
	1.  New blocks would result into addition of new nodes into RVT.
	2.  Pruning would result into removal of nodes from RVT.