### PR TITLE
RangeValidationTree: refactor NodeInfo,RVTNode, fix bugs

### DIFF
--- a/bftengine/src/bcstatetransfer/RVBManager.cpp
+++ b/bftengine/src/bcstatetransfer/RVBManager.cpp
@@ -100,7 +100,7 @@ void RVBManager::init(bool fetching) {
 
   LOG_INFO(logger_, std::boolalpha << KVLOG(pruned_blocks_digests_.size(), desc.checkpointNum, loaded_from_data_store));
   if (print_rvt && (debug_prints_log_level.find(getLogLevel()) != debug_prints_log_level.end())) {
-    in_mem_rvt_->printToLog(false);
+    in_mem_rvt_->printToLog(LogPrintVerbosity::DETAILED);
   }
 }
 
@@ -221,7 +221,7 @@ void RVBManager::updateRvbDataDuringCheckpoint(CheckpointDesc& new_checkpoint_de
     const std::string s = rvb_data.str();
     ConcordAssert(!s.empty());
     std::copy(s.c_str(), s.c_str() + s.length(), back_inserter(new_checkpoint_desc.rvbData));
-    in_mem_rvt_->printToLog(false);
+    in_mem_rvt_->printToLog(LogPrintVerbosity::DETAILED);
   }
   last_checkpoint_desc_ = new_checkpoint_desc;
 }
@@ -357,7 +357,7 @@ bool RVBManager::setSerializedDigestsOfRvbGroup(char* data,
       LOG_ERROR(logger_, error_prefix << KVLOG(block_id, next_expected_rvb_id));
       return false;
     }
-    rvb_group_ids = in_mem_rvt_->getRvbGroupIds(block_id, block_id);
+    rvb_group_ids = in_mem_rvt_->getRvbGroupIds(block_id, block_id, true);
     ConcordAssertEQ(rvb_group_ids.size(), 1);
     if (rvb_group_ids.empty()) {
       LOG_ERROR(logger_, "Bad Digests of RVB group: rvb_group_ids is empty!" << KVLOG(block_id));
@@ -427,7 +427,7 @@ bool RVBManager::setSerializedDigestsOfRvbGroup(char* data,
     stored_rvb_digests_group_ids_.erase(stored_rvb_digests_group_ids_.begin());
     auto it = stored_rvb_digests_.begin();
     while (it != stored_rvb_digests_.end()) {
-      rvb_group_ids = in_mem_rvt_->getRvbGroupIds(it->first, it->first);
+      rvb_group_ids = in_mem_rvt_->getRvbGroupIds(it->first, it->first, true);
       ConcordAssertEQ(rvb_group_ids.size(), 1);
       if (rvb_group_ids[0] == rvb_group_id_removed) {
         it = stored_rvb_digests_.erase(it);
@@ -492,7 +492,7 @@ RVBGroupId RVBManager::getFetchBlocksRvbGroupId(BlockId from_block_id, BlockId t
 RVBGroupId RVBManager::getNextRequiredRvbGroupid(RVBId from_rvb_id, RVBId to_rvb_id) const {
   LOG_TRACE(logger_, KVLOG(from_rvb_id, to_rvb_id));
   if (from_rvb_id > to_rvb_id) return 0;
-  const auto rvb_group_ids = in_mem_rvt_->getRvbGroupIds(from_rvb_id, to_rvb_id);
+  const auto rvb_group_ids = in_mem_rvt_->getRvbGroupIds(from_rvb_id, to_rvb_id, true);
   for (const auto& id : rvb_group_ids) {
     if (std::find(stored_rvb_digests_group_ids_.begin(), stored_rvb_digests_group_ids_.end(), id) ==
         stored_rvb_digests_group_ids_.end()) {
@@ -512,7 +512,7 @@ BlockId RVBManager::getRvbGroupMaxBlockIdOfNonStoredRvbGroup(BlockId from_block_
     return to_block_id;
   }
 
-  const auto rvb_group_ids = in_mem_rvt_->getRvbGroupIds(min_rvb_id, max_rvb_id);
+  const auto rvb_group_ids = in_mem_rvt_->getRvbGroupIds(min_rvb_id, max_rvb_id, true);
   if (rvb_group_ids.size() < 2) {
     return to_block_id;
   }

--- a/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
+++ b/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
@@ -723,23 +723,23 @@ void BcStTestDelegator::validateEqualRVTs(const RangeValidationTree& rvtA, const
   ASSERT_EQ(rvtA.totalLevels(), rvtB.totalLevels());
   ASSERT_EQ(rvtA.getMinRvbId(), rvtB.getMinRvbId());
   ASSERT_EQ(rvtA.getMaxRvbId(), rvtB.getMaxRvbId());
-  ASSERT_EQ(rvtA.rightmostRVTNode_.size(), rvtB.rightmostRVTNode_.size());
-  ASSERT_EQ(rvtA.leftmostRVTNode_.size(), rvtB.leftmostRVTNode_.size());
-  ASSERT_EQ(rvtA.leftmostRVTNode_.size(), RangeValidationTree::NodeInfo::kMaxLevels);
-  ASSERT_EQ(rvtA.rightmostRVTNode_.size(), RangeValidationTree::NodeInfo::kMaxLevels);
+  ASSERT_EQ(rvtA.rightmost_rvt_node_.size(), rvtB.rightmost_rvt_node_.size());
+  ASSERT_EQ(rvtA.leftmost_rvt_node_.size(), rvtB.leftmost_rvt_node_.size());
+  ASSERT_EQ(rvtA.leftmost_rvt_node_.size(), RangeValidationTree::NodeInfo::kMaxLevels);
+  ASSERT_EQ(rvtA.rightmost_rvt_node_.size(), RangeValidationTree::NodeInfo::kMaxLevels);
 
-  const auto& rmA = rvtA.rightmostRVTNode_;
-  const auto& rmB = rvtB.rightmostRVTNode_;
-  const auto& lmA = rvtA.leftmostRVTNode_;
-  const auto& lmB = rvtB.leftmostRVTNode_;
+  const auto& rmA = rvtA.rightmost_rvt_node_;
+  const auto& rmB = rvtB.rightmost_rvt_node_;
+  const auto& lmA = rvtA.leftmost_rvt_node_;
+  const auto& lmB = rvtB.leftmost_rvt_node_;
   for (size_t i{}; i < RangeValidationTree::NodeInfo::kMaxLevels; ++i) {
     if (rmA[i]) {
-      ASSERT_EQ(rmA[i]->info_.id, rmB[i]->info_.id);
+      ASSERT_EQ(rmA[i]->info_.id(), rmB[i]->info_.id());
     } else {
       ASSERT_EQ(rmA[i], rmB[i]);
     }
     if (lmA[i]) {
-      ASSERT_EQ(lmA[i]->info_.id, lmB[i]->info_.id);
+      ASSERT_EQ(lmA[i]->info_.id(), lmB[i]->info_.id());
     } else {
       ASSERT_EQ(lmA[i], lmB[i]);
     }
@@ -747,10 +747,9 @@ void BcStTestDelegator::validateEqualRVTs(const RangeValidationTree& rvtA, const
   ASSERT_EQ(rvtA.max_rvb_index_, rvtB.max_rvb_index_);
   ASSERT_EQ(rvtA.min_rvb_index_, rvtB.min_rvb_index_);
   if (rvtA.root_ && (rvtA.root_ == rvtB.root_)) {
-    ASSERT_EQ(rvtA.root_->n_child, rvtB.root_->n_child);
-    ASSERT_EQ(rvtA.root_->min_child_id, rvtB.root_->min_child_id);
-    ASSERT_EQ(rvtA.root_->max_child_id, rvtB.root_->max_child_id);
-    ASSERT_EQ(rvtA.root_->parent_id, rvtB.root_->parent_id);
+    ASSERT_EQ(rvtA.root_->numChildren(), rvtB.root_->numChildren());
+    ASSERT_EQ(rvtA.root_->parent_id_, rvtB.root_->parent_id_);
+    ASSERT_EQ(rvtA.root_->insertion_counter_, rvtB.root_->insertion_counter_);
   }
 }
 
@@ -1878,8 +1877,8 @@ TEST_P(BcStTestParamFixture3, bkpValidateCheckpointingWithConsensusCommitsAndPru
     ASSERT_TRUE(!helper_rvt.getRootCurrentValueStr().empty());
 
     // leave for debug
-    // helper_rvt.printToLog(false);
-    // rvt->printToLog(false);
+    // helper_rvt.printToLog(LogPrintVerbosity::DETAILED);
+    // rvt->printToLog(LogPrintVerbosity::DETAILED);
 
     // when only pruning, tree must shrink over time
     // when only adding tree must grow over time


### PR DESCRIPTION
1) Rewrite getRvbGroupId().
2) Add LogPrintVerbosity, to print tree in 2 modes.
3) Refactor NodeInfo, add helper functions.
4) Fix the way we calculate rvb_index, also support case in which not
the 1st node in span is rhe one which opens a new parent.
5) Each EVT node holds now a vector of childs, and last_insertion_index.
6) Add getRVTNodeByType() to support all cases where a node is needed
(parent, siblings etc.)
7) Update open rightmost/leftmost arrays in a dedicated function
updateOpenRvtNodeArrays.
8) Other bug fixes.