### PR TITLE
state transfer : Refill preferred list after last source removal

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -368,7 +368,7 @@ void BCStateTran::initImpl(uint64_t maxNumOfRequiredStoredCheckpoints,
         LOG_INFO(logger_, "State Transfer cycle continues");
         startCollectingStats();
         if ((fs == FetchingState::GettingMissingBlocks) || (fs == FetchingState::GettingMissingResPages)) {
-          SetAllReplicasAsPreferred();
+          setAllReplicasAsPreferred();
         }
 
         if (fs == FetchingState::GettingMissingBlocks) {
@@ -2138,6 +2138,7 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
                                                                              m->msgSeqNum,
                                                                              m->lastCheckpointKnownToRequester,
                                                                              m->requiredCheckpointNum,
+                                                                             psd_->getLastStoredCheckpoint(),
                                                                              m->lastKnownChunk));
 
     metrics_.sent_reject_fetch_msg_++;
@@ -2268,27 +2269,19 @@ bool BCStateTran::onMessage(const RejectFetchingMsg *m, uint32_t msgLen, uint16_
     return false;
   }
 
-  if (sourceSelector_.isPreferredSourceId(replicaId)) {
-    LOG_WARN(logger_, "Removing replica from preferred replicas: " << KVLOG(replicaId));
-    sourceSelector_.removeCurrentReplica();
-    clearAllPendingItemsData();
-  }
-
-  if (sourceSelector_.hasPreferredReplicas()) {
-    processData();
-  } else if (fs == FetchingState::GettingMissingBlocks) {
-    LOG_DEBUG(logger_, "Adding all peer replicas to preferredReplicas_ (because preferredReplicas_.size()==0)");
-
-    // in this case, we will try to use all other replicas (remove current replica)
-    SetAllReplicasAsPreferred();
-    sourceSelector_.removeCurrentReplica();
-    processData();
-  } else if (fs == FetchingState::GettingMissingResPages) {
-    // enter new cycle
+  if (fs == FetchingState::GettingMissingResPages) {
+    sourceSelector_.reset();
     startCollectingStateInternal();
-  } else {
-    ConcordAssert(false);
+    return false;
   }
+
+  // Infinite loop here on gettingMissingBlocks state
+  // TBD source selector keeps filling preferred replicas list when it removes last entry
+  sourceSelector_.removeCurrentReplica();
+  ConcordAssert(sourceSelector_.hasPreferredReplicas());
+  clearAllPendingItemsData();
+  processData();
+
   return false;
 }
 
@@ -2781,7 +2774,7 @@ set<uint16_t> BCStateTran::allOtherReplicas() {
   return others;
 }
 
-void BCStateTran::SetAllReplicasAsPreferred() { sourceSelector_.setAllReplicasAsPreferred(); }
+void BCStateTran::setAllReplicasAsPreferred() { sourceSelector_.checkAndRefillPreferredReplicas(); }
 
 void BCStateTran::reportCollectingStatus(const uint32_t actualBlockSize, bool toLog) {
   metrics_.overall_blocks_collected_++;

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -475,7 +475,7 @@ class BCStateTran : public IStateTransfer {
   void cycleEndSummary();
   void onGettingMissingBlocksEnd(DataStoreTransaction* txn);
   set<uint16_t> allOtherReplicas();
-  void SetAllReplicasAsPreferred();
+  void setAllReplicasAsPreferred();
 
   ///////////////////////////////////////////////////////////////////////////
   // Helper methods

--- a/bftengine/src/bcstatetransfer/SourceSelector.cpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.cpp
@@ -34,10 +34,20 @@ void SourceSelector::setFetchingTimeStamp(uint64_t currTimeMilli, bool retransmi
 void SourceSelector::removeCurrentReplica() {
   preferredReplicas_.erase(currentReplica_);
   currentReplica_ = NO_REPLICA;
+  checkAndRefillPreferredReplicas();
   receivedValidBlockFromSrc_ = false;
   setSourceSelectionTime(0);
   metrics_.current_source_replica_.Get().Set(currentReplica_);
   metrics_.preferred_replicas_.Get().Set(preferredReplicasToString());
+}
+
+void SourceSelector::removePreferredReplica(uint16_t replicaId) {
+  if (preferredReplicas_.find(replicaId) == preferredReplicas_.end()) {
+    LOG_WARN(logger_, "Not found" << KVLOG(replicaId));
+    return;
+  }
+  preferredReplicas_.erase(replicaId);
+  checkAndRefillPreferredReplicas();
 }
 
 void SourceSelector::onReceivedValidBlockFromSource() {
@@ -47,11 +57,6 @@ void SourceSelector::onReceivedValidBlockFromSource() {
     LOG_INFO(logger_, "Insert source " << currentReplica_ << " into actualSources_");
     actualSources_.push_back(currentReplica_);
   }
-}
-
-void SourceSelector::setAllReplicasAsPreferred() {
-  preferredReplicas_ = allOtherReplicas_;
-  metrics_.preferred_replicas_.Get().Set(preferredReplicasToString());
 }
 
 void SourceSelector::reset() {
@@ -103,17 +108,22 @@ uint64_t SourceSelector::timeSinceSourceSelectedMilli(uint64_t currTimeMilli) co
              : (currTimeMilli - sourceSelectionTimeMilli_);
 }
 
-// Replace the source.
-void SourceSelector::updateSource(uint64_t currTimeMilli) {
-  if (currentReplica_ != NO_REPLICA) {
-    preferredReplicas_.erase(currentReplica_);
-  }
+void SourceSelector::checkAndRefillPreferredReplicas() {
   if (preferredReplicas_.empty()) {
     preferredReplicas_ = allOtherReplicas_;
     if (currentPrimary_ != NO_REPLICA) {
       preferredReplicas_.erase(currentPrimary_);
     }
+    metrics_.preferred_replicas_.Get().Set(preferredReplicasToString());
   }
+}
+
+// Replace the source.
+void SourceSelector::updateSource(uint64_t currTimeMilli) {
+  if (currentReplica_ != NO_REPLICA) {
+    preferredReplicas_.erase(currentReplica_);
+  }
+  checkAndRefillPreferredReplicas();
   selectSource(currTimeMilli);
 }
 

--- a/bftengine/src/bcstatetransfer/SourceSelector.hpp
+++ b/bftengine/src/bcstatetransfer/SourceSelector.hpp
@@ -72,7 +72,6 @@ class SourceSelector {
 
   bool hasSource() const;
   void removeCurrentReplica();
-  void setAllReplicasAsPreferred();
   void reset();
   bool isReset() const;
   bool retransmissionTimeoutExpired(uint64_t currTimeMilli) const;
@@ -106,7 +105,7 @@ class SourceSelector {
 
   uint16_t currentPrimary() { return currentPrimary_; }
 
-  void removePreferredReplica(uint16_t replicaId) { preferredReplicas_.erase(replicaId); }
+  void removePreferredReplica(uint16_t replicaId);
 
   uint16_t numberOfPreferredReplicas() const { return static_cast<uint16_t>(preferredReplicas_.size()); }
 
@@ -123,6 +122,8 @@ class SourceSelector {
   void updateCurrentPrimary(uint16_t newPrimaryReplicaId);
 
   uint16_t minPrePrepareMsgsForPrimaryAwareness() { return minPrePrepareMsgsForPrimaryAwareness_; }
+
+  void checkAndRefillPreferredReplicas();
 
   // Metric
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {

--- a/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
+++ b/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
@@ -1703,6 +1703,31 @@ TEST_F(BcStTest, dstSendPrePrepareMsgsDuringStateTransfer) {
   ASSERT_NFF(dstValidateCycleEnd(10));
 }
 
+TEST_F(BcStTest, dstProcessDataWithNoKnownSources) {
+  ASSERT_NFF(initialize());
+  ASSERT_NFF(dstStartRunningAndCollecting());
+  ASSERT_NFF(fakeSrcReplica_->replyAskForCheckpointSummariesMsg());
+  auto& ss = stDelegator_->getSourceSelector();
+
+  // Scenario:
+  // Retransmission time out reached (or some other bad reason) for f replicas & new source selected.
+  // This newly selected source is apparently last source in preferred list.
+  // Destination sends fetchBlockMsg() to new (also last one) source.
+  // This newly selected source becomes primary & as a result it also gets removed from preferred list.
+  // Assert will hit as destination replica assumes that there is at least one source replica in preferred list
+  // to get (V)block.
+
+  while (ss.numberOfPreferredReplicas() > 1) {
+    ss.updateSource(getMonotonicTimeMilli());
+  }
+  ss.removeCurrentReplica();
+
+  ASSERT_NFF(getMissingblocksStage(EMPTY_FUNC, EMPTY_FUNC));
+  ASSERT_NFF(getReservedPagesStage());
+  // validate completion
+  ASSERT_NFF(dstValidateCycleEnd(10));
+}
+
 TEST_F(BcStTest, dstPreprepareFromMultipleSourcesDuringStateTransfer) {
   ASSERT_NFF(initialize());
   std::once_flag once_flag;

--- a/bftengine/tests/bcstatetransfer/source_selector_test.cpp
+++ b/bftengine/tests/bcstatetransfer/source_selector_test.cpp
@@ -117,7 +117,7 @@ TEST_F(SourceSelectorTestFixture, on_construction_is_reset_reports_true) { ASSER
 
 TEST_F(SourceSelectorTestFixture, leave_initial_state_when_there_are_any_preferred_replicas) {
   ASSERT_TRUE(source_selector.isReset());
-  source_selector.setAllReplicasAsPreferred();
+  source_selector.checkAndRefillPreferredReplicas();
   ASSERT_FALSE(source_selector.isReset());
 }
 
@@ -135,7 +135,7 @@ TEST_F(SourceSelectorTestFixture, leave_initial_state_when_the_fetching_timestam
 
 TEST_F(SourceSelectorTestFixture, reset_removes_preferred_replicas) {
   ASSERT_EQ(source_selector.numberOfPreferredReplicas(), 0);
-  source_selector.setAllReplicasAsPreferred();
+  source_selector.checkAndRefillPreferredReplicas();
   ASSERT_EQ(source_selector.numberOfPreferredReplicas(), replicas.size());
   source_selector.reset();
   ASSERT_EQ(source_selector.numberOfPreferredReplicas(), 0);
@@ -174,7 +174,7 @@ TEST_F(SourceSelectorTestFixture, reset_sets_the_fetching_timestamp_to_zero) {
 // Others
 TEST_F(SourceSelectorTestFixture, set_all_replicas_as_preferred) {
   ASSERT_FALSE(source_selector.hasPreferredReplicas());
-  source_selector.setAllReplicasAsPreferred();
+  source_selector.checkAndRefillPreferredReplicas();
   ASSERT_TRUE(source_selector.hasPreferredReplicas());
 
   for (const auto& replica : replicas) {


### PR DESCRIPTION
Whenever last source replica id is removed from preferred list, list
would be refilled again with all the available sources except current
primary replica id.