### PR TITLE
Convert state-transfer messages to smart pointers

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -1110,11 +1110,19 @@ void BCStateTran::setEraseMetadataFlagImpl() { psd_->setEraseDataStoreFlag(); }
 
 void BCStateTran::setReconfigurationEngineImpl(std::shared_ptr<ClientReconfigurationEngine> cre) { cre_ = cre; }
 
+template <typename MSG>
+void BCStateTran::freeStateTransferMsg(const MSG *m) {
+  const char *p_to_delete = (reinterpret_cast<const char *>(m) - sizeof(MessageBase::Header));
+  std::free(const_cast<char *>(p_to_delete));
+}
+
 // this function can be executed in context of another thread.
 void BCStateTran::handleStateTransferMessageImpl(char *msg,
                                                  uint32_t msgLen,
                                                  uint16_t senderId,
                                                  LocalTimePoint incomingEventsQPushTime) {
+  // msgHeader is now the owner of msg. after getting true type of msg, the ownership will be of onMessage functions.
+  auto msgHeader = STMessageUptr<BCStateTranBaseMsg>(reinterpret_cast<BCStateTranBaseMsg *>(msg));
   if (!running_) {
     return;
   }
@@ -1128,63 +1136,61 @@ void BCStateTran::handleStateTransferMessageImpl(char *msg,
   if (msgSizeTooSmall || sentFromSelf || invalidSender) {
     metrics_.received_illegal_msg_++;
     LOG_WARN(logger_, "Illegal message: " << KVLOG(msgLen, senderId, msgSizeTooSmall, sentFromSelf, invalidSender));
-    replicaForStateTransfer_->freeStateTransferMsg(msg);
     time_in_incoming_events_queue_rec_.start();
     return;
   }
 
-  BCStateTranBaseMsg *msgHeader = reinterpret_cast<BCStateTranBaseMsg *>(msg);
   LOG_DEBUG(logger_, "new message with type=" << msgHeader->type);
 
   FetchingState fs = getFetchingState();
-  bool freeMessage{true};
   switch (msgHeader->type) {
-    case MsgType::AskForCheckpointSummaries:
+    case MsgType::AskForCheckpointSummaries: {
       if (fs == FetchingState::NotFetching) {
 #ifdef ENABLE_ALL_METRICS
         metrics_.handle_AskForCheckpointSummaries_msg_++;
 #endif
-        freeMessage = onMessage(reinterpret_cast<AskForCheckpointSummariesMsg *>(msg), msgLen, senderId);
+        onMessage(convertBaseStMsgToRealStMsgType<AskForCheckpointSummariesMsg>(msgHeader.release()), msgLen, senderId);
       }
-      break;
-    case MsgType::CheckpointsSummary:
+    } break;
+    case MsgType::CheckpointsSummary: {
       if (fs == FetchingState::GettingCheckpointSummaries) {
 #ifdef ENABLE_ALL_METRICS
         metrics_.handle_CheckpointsSummary_msg_++;
 #endif
-        freeMessage = onMessage(reinterpret_cast<CheckpointSummaryMsg *>(msg), msgLen, senderId);
+        onMessage(convertBaseStMsgToRealStMsgType<CheckpointSummaryMsg>(msgHeader.release()), msgLen, senderId);
       }
-      break;
+    } break;
     case MsgType::FetchBlocks: {
       TimeRecorder scoped_timer(*histograms_.src_handle_FetchBlocks_msg_duration);
       metrics_.handle_FetchBlocks_msg_++;
-      freeMessage = onMessage(reinterpret_cast<FetchBlocksMsg *>(msg), msgLen, senderId);
+      onMessage(convertBaseStMsgToRealStMsgType<FetchBlocksMsg>(msgHeader.release()), msgLen, senderId);
     } break;
     case MsgType::FetchResPages: {
       TimeRecorder scoped_timer(*histograms_.src_handle_FetchResPages_msg_duration);
       metrics_.handle_FetchResPages_msg_++;
-      freeMessage = onMessage(reinterpret_cast<FetchResPagesMsg *>(msg), msgLen, senderId);
+      onMessage(convertBaseStMsgToRealStMsgType<FetchResPagesMsg>(msgHeader.release()), msgLen, senderId);
     } break;
-    case MsgType::RejectFetching:
+    case MsgType::RejectFetching: {
       if (fs == FetchingState::GettingMissingBlocks || fs == FetchingState::GettingMissingResPages) {
         metrics_.handle_RejectFetching_msg_++;
-        freeMessage = onMessage(reinterpret_cast<RejectFetchingMsg *>(msg), msgLen, senderId);
+        onMessage(convertBaseStMsgToRealStMsgType<RejectFetchingMsg>(msgHeader.release()), msgLen, senderId);
       }
-      break;
-    case MsgType::ItemData:
+    } break;
+    case MsgType::ItemData: {
       if (fs == FetchingState::GettingMissingBlocks || fs == FetchingState::GettingMissingResPages) {
         TimeRecorder scoped_timer(*histograms_.dst_handle_ItemData_msg);
         metrics_.handle_ItemData_msg_++;
-        freeMessage = onMessage(reinterpret_cast<ItemDataMsg *>(msg), msgLen, senderId, incomingEventsQPushTime);
+        onMessage(convertBaseStMsgToRealStMsgType<ItemDataMsg>(msgHeader.release()),
+                  msgLen,
+                  senderId,
+                  incomingEventsQPushTime);
       }
-      break;
+    } break;
     default:
+      LOG_WARN(GL, "Unknown type of state transfer msg" << KVLOG(msgHeader->type));
       break;
   }
 
-  if (freeMessage) {
-    replicaForStateTransfer_->freeStateTransferMsg(msg);
-  }
   time_in_incoming_events_queue_rec_.start();
 }
 
@@ -1617,7 +1623,7 @@ void BCStateTran::sendFetchResPagesMsg(int16_t lastKnownChunkInLastRequiredBlock
 // Message handlers
 //////////////////////////////////////////////////////////////////////////////
 
-bool BCStateTran::onMessage(const AskForCheckpointSummariesMsg *m, uint32_t msgLen, uint16_t replicaId) {
+void BCStateTran::onMessage(STMessageUptr<AskForCheckpointSummariesMsg> m, uint32_t msgLen, uint16_t replicaId) {
   SCOPED_MDC_SEQ_NUM(getScopedMdcStr(replicaId, m->msgSeqNum));
   LOG_INFO(logger_, KVLOG(replicaId, m->msgSeqNum));
 
@@ -1629,7 +1635,7 @@ bool BCStateTran::onMessage(const AskForCheckpointSummariesMsg *m, uint32_t msgL
 #ifdef ENABLE_ALL_METRICS
     metrics_.invalid_ask_for_checkpoint_summaries_msg_++;
 #endif
-    return true;
+    return;
   }
 
   // if msg is not relevant
@@ -1643,7 +1649,7 @@ bool BCStateTran::onMessage(const AskForCheckpointSummariesMsg *m, uint32_t msgL
 #ifdef ENABLE_ALL_METRICS
     metrics_.irrelevant_ask_for_checkpoint_summaries_msg_++;
 #endif
-    return true;
+    return;
   }
 
   uint64_t toCheckpoint = lastStoredCheckpoint;
@@ -1677,8 +1683,7 @@ bool BCStateTran::onMessage(const AskForCheckpointSummariesMsg *m, uint32_t msgL
                                                        msg->requestMsgSeqNum,
                                                        msg->sizeofRvbData()));
 
-    replicaForStateTransfer_->sendStateTransferMessage(reinterpret_cast<char *>(msg), msg->size(), toReplicaId);
-    CheckpointSummaryMsg::free(msg);
+    replicaForStateTransfer_->sendStateTransferMessage(msg.getSerializedMsg(), msg->size(), toReplicaId);
     metrics_.sent_checkpoint_summary_msg_++;
     sent = true;
   }
@@ -1686,10 +1691,10 @@ bool BCStateTran::onMessage(const AskForCheckpointSummariesMsg *m, uint32_t msgL
   if (!sent) {
     LOG_INFO(logger_, "Failed to send relevant CheckpointSummaryMsg: " << KVLOG(toReplicaId));
   }
-  return true;
+  return;
 }
 
-bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint16_t replicaId) {
+void BCStateTran::onMessage(STMessageUptr<CheckpointSummaryMsg> m, uint32_t msgLen, uint16_t replicaId) {
   SCOPED_MDC_SEQ_NUM(getScopedMdcStr(config_.myReplicaId, uniqueMsgSeqNum()));
   LOG_INFO(logger_, KVLOG(replicaId, m->checkpointNum, m->maxBlockId, m->requestMsgSeqNum, m->sizeofRvbData()));
 
@@ -1701,7 +1706,7 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
 #ifdef ENABLE_ALL_METRICS
     metrics_.irrelevant_checkpoint_summary_msg_++;
 #endif
-    return true;
+    return;
   }
 
   // if msg is invalid
@@ -1711,7 +1716,7 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
              "Msg is invalid: " << KVLOG(
                  replicaId, msgLen, m->checkpointNum, m->digestOfResPagesDescriptor.isZero(), m->requestMsgSeqNum));
     metrics_.invalid_checkpoint_summary_msg_++;
-    return true;
+    return;
   }
 
   // if msg is not relevant
@@ -1722,7 +1727,7 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
 #ifdef ENABLE_ALL_METRICS
     metrics_.irrelevant_checkpoint_summary_msg_++;
 #endif
-    return true;
+    return;
   }
 
   uint16_t numOfMsgsFromSender =
@@ -1731,31 +1736,31 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
   // if we have too many messages from the same replica
   if (numOfMsgsFromSender >= (psd_->getMaxNumOfStoredCheckpoints() + 1)) {
     LOG_WARN(logger_, "Too many messages from replica: " << KVLOG(replicaId, numOfMsgsFromSender));
-    return true;
+    return;
   }
 
-  auto p = summariesCerts.find(m->checkpointNum);
-  CheckpointSummaryMsgCert *cert = nullptr;
-
-  if (p == summariesCerts.end()) {
-    cert = new CheckpointSummaryMsgCert(
-        replicaForStateTransfer_, replicas_.size(), config_.fVal, config_.fVal + 1, config_.myReplicaId);
-    summariesCerts[m->checkpointNum] = cert;
-  } else {
-    cert = p->second;
+  if (summariesCerts.find(m->checkpointNum) == summariesCerts.end()) {
+    summariesCerts.emplace(
+        m->checkpointNum,
+        new CheckpointSummaryMsgCert(
+            replicaForStateTransfer_, replicas_.size(), config_.fVal, config_.fVal + 1, config_.myReplicaId));
   }
+  auto pos = summariesCerts.find(m->checkpointNum);
+  ConcordAssertNE(pos, summariesCerts.end());
+  auto &cert = *pos->second;
 
-  bool used = cert->addMsg(const_cast<CheckpointSummaryMsg *>(m), replicaId);
+  // TODO: Should adjust MsgsCertificate to allow smart pointers. Meanwhile, pass here a raw pointer
+  bool used = cert.addMsg(const_cast<CheckpointSummaryMsg *>(m.release()), replicaId);
 
   if (used) numOfSummariesFromOtherReplicas[replicaId] = numOfMsgsFromSender + 1;
 
-  if (!cert->isComplete()) {
+  if (!cert.isComplete()) {
     LOG_INFO(logger_, "Does not have enough CheckpointSummaryMsg messages");
-    return false;
+    return;
   }
 
   LOG_INFO(logger_, "Has enough CheckpointSummaryMsg messages");
-  CheckpointSummaryMsg *cpSummaryMsg = cert->bestCorrectMsg();
+  CheckpointSummaryMsg *cpSummaryMsg = cert.bestCorrectMsg();
 
   ConcordAssertNE(cpSummaryMsg, nullptr);
   ConcordAssert(sourceSelector_.isReset());
@@ -1776,14 +1781,14 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
     LOG_ERROR(logger_, "Failed to set new RVT data! restart cycle...");
     // enter new cycle
     startCollectingStateInternal();
-    return false;
+    return;
   }
   metrics_.current_rvb_data_state_.Get().Set(rvbm_->getStateOfRvbData());
 
   // set the preferred replicas
   for (uint16_t r : replicas_) {  // TODO(GG): can be improved
-    CheckpointSummaryMsg *t = cert->getMsgFromReplica(r);
-    if (t != nullptr && CheckpointSummaryMsg::equivalent(t, cpSummaryMsg)) {
+    CheckpointSummaryMsg *otherRepCpSummaryMsg = cert.getMsgFromReplica(r);
+    if (otherRepCpSummaryMsg != nullptr && CheckpointSummaryMsg::equivalent(otherRepCpSummaryMsg, cpSummaryMsg)) {
       sourceSelector_.addPreferredReplica(r);
       ConcordAssertLT(r, config_.numReplicas);
     }
@@ -1842,7 +1847,7 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
   metrics_.last_block_.Get().Set(newCheckpoint.maxBlockId);
 
   processData();
-  return false;
+  return;
 }
 
 uint16_t BCStateTran::getBlocksConcurrentAsync(uint64_t maxBlockId, uint64_t minBlockId, uint16_t numBlocks) {
@@ -1953,7 +1958,7 @@ void BCStateTran::sourcePrepareBatch(uint64_t numBlocksRequested) {
   }
 }
 
-bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t replicaId) {
+void BCStateTran::onMessage(STMessageUptr<FetchBlocksMsg> m, uint32_t msgLen, uint16_t replicaId) {
   SCOPED_MDC_SEQ_NUM(getScopedMdcStr(replicaId, m->msgSeqNum));
   LOG_INFO(logger_,
            KVLOG(replicaId,
@@ -1979,7 +1984,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
 #ifdef ENABLE_ALL_METRICS
     metrics_.invalid_fetch_blocks_msg_++;
 #endif
-    return true;
+    return;
   }
 
   // if msg is not relevant
@@ -1988,13 +1993,13 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
 #ifdef ENABLE_ALL_METRICS
     metrics_.irrelevant_fetch_blocks_msg_++;
 #endif
-    return true;
+    return;
   }
 
   uint64_t numBlocksRequested = static_cast<uint64_t>(m->maxBlockId - m->minBlockId + 1);
   if (numBlocksRequested > config_.maxNumberOfChunksInBatch) {
     sendRejectFetchingMsg(RejectFetchingMsg::Reason::INVALID_NUMBER_OF_BLOCKS_REQUESTED, m->msgSeqNum, replicaId);
-    return true;
+    return;
   }
 
   FetchingState fetchingState = getFetchingState();
@@ -2003,14 +2008,14 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
   // Reject if I'm already in ST (source or destination)
   if (isActiveDestination(fetchingState)) {
     sendRejectFetchingMsg(RejectFetchingMsg::Reason::IN_STATE_TRANSFER, m->msgSeqNum, replicaId);
-    return true;
+    return;
   }
   if (m->maxBlockId > lastReachableBlockNum) {
     sendRejectFetchingMsg(RejectFetchingMsg::Reason::BLOCK_RANGE_NOT_FOUND,
                           m->msgSeqNum,
                           replicaId,
                           KVLOG(m->maxBlockId, lastReachableBlockNum));
-    return true;
+    return;
   }
   auto [sessionOpened, otherReplicaSessionClosed] = sourceSession_.tryOpen(replicaId);
   (void)otherReplicaSessionClosed;
@@ -2018,7 +2023,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
     auto additionalInfo =
         "Active session with ownerDestReplicaId=" + std::to_string(sourceSession_.ownerDestReplicaId());
     sendRejectFetchingMsg(RejectFetchingMsg::Reason::IN_ACTIVE_SESSION, m->msgSeqNum, replicaId, additionalInfo);
-    return true;
+    return;
   }
   // comment: otherReplicaSessionClosed is supposed to mark the need to clear io contexts.
   // To save time, do it later and not here.
@@ -2030,7 +2035,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
     sendRejectFetchingMsg(
         RejectFetchingMsg::Reason::DIGESTS_FOR_RVBGROUP_NOT_FOUND, m->msgSeqNum, replicaId, additionalInfo);
     sourceSession_.close();
-    return true;
+    return;
   }
 
   // start recording time to send a whole batch, and its size
@@ -2045,7 +2050,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
                     (m->lastKnownChunkInLastRequiredBlock == 0),
                     config_,
                     rvbGroupDigestsExpectedSize,
-                    m,
+                    m.get(),
                     replicaId);
   ConcordAssertEQ(sourceBatch_.destReplicaId, sourceSession_.ownerDestReplicaId());
 
@@ -2059,7 +2064,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
                                                                      m->lastKnownChunkInLastRequiredBlock,
                                                                      m->rvbGroupId));
   continueSendBatch();
-  return true;
+  return;
 }
 
 void BCStateTran::continueSendBatch() {
@@ -2137,13 +2142,12 @@ void BCStateTran::continueSendBatch() {
     ConcordAssertGT(chunkSize, 0);
 
     char *pRawChunk = buffer + (sb.nextChunk - 1) * config_.maxChunkSize;
-    ItemDataMsg *outMsg = ItemDataMsg::alloc(chunkSize + sb.rvbGroupDigestsExpectedSize);  // TODO(GG): improve
+    auto outMsg = ItemDataMsg::alloc(chunkSize + sb.rvbGroupDigestsExpectedSize);
 
     outMsg->requestMsgSeqNum = m->msgSeqNum;
     outMsg->blockNumber = sb.nextBlockId;
     outMsg->totalNumberOfChunksInBlock = numOfChunksInNextBlock;
     outMsg->chunkNumber = sb.nextChunk;
-    outMsg->dataSize = chunkSize + sb.rvbGroupDigestsExpectedSize;
 
     outMsg->lastInBatch =
         ((sb.numSentChunks + 1) >= config_.maxNumberOfChunksInBatch) || ((sb.nextBlockId - 1) < m->minBlockId);
@@ -2159,7 +2163,6 @@ void BCStateTran::continueSendBatch() {
       if ((rvbGroupDigestsActualSize == 0) || (sb.rvbGroupDigestsExpectedSize != rvbGroupDigestsActualSize)) {
         auto additionalInfo = "Rejecting message - not holding all requested digests (or some other error)" +
                               KVLOG(sb.rvbGroupDigestsExpectedSize, rvbGroupDigestsActualSize);
-        ItemDataMsg::free(outMsg);
         sendRejectFetchingMsg(
             RejectFetchingMsg::Reason::DIGESTS_FOR_RVBGROUP_NOT_FOUND, m->msgSeqNum, sb.destReplicaId, additionalInfo);
         sourceSession_.close();
@@ -2184,16 +2187,14 @@ void BCStateTran::continueSendBatch() {
                                                outMsg->blockNumber,
                                                outMsg->totalNumberOfChunksInBlock,
                                                outMsg->chunkNumber,
-                                               outMsg->dataSize,
+                                               outMsg->getDataSize(),
                                                outMsg->rvbDigestsSize,
                                                (bool)outMsg->lastInBatch));
 
     metrics_.sent_item_data_msg_++;
-    replicaForStateTransfer_->sendStateTransferMessage(
-        reinterpret_cast<char *>(outMsg), outMsg->size(), sb.destReplicaId);
+    replicaForStateTransfer_->sendStateTransferMessage(outMsg.getSerializedMsg(), outMsg->size(), sb.destReplicaId);
     ++sb.numSentChunks;
     sb.numSentBytes += (chunkSize + sb.rvbGroupDigestsExpectedSize);
-    ItemDataMsg::free(outMsg);
 
     auto finalizeContext = [&]() {
       ioPool_.free(ctx);
@@ -2262,7 +2263,7 @@ void BCStateTran::continueSendBatch() {
   return;
 }
 
-bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t replicaId) {
+void BCStateTran::onMessage(STMessageUptr<FetchResPagesMsg> m, uint32_t msgLen, uint16_t replicaId) {
   SCOPED_MDC_SEQ_NUM(getScopedMdcStr(replicaId, m->msgSeqNum));
   LOG_INFO(
       logger_,
@@ -2275,7 +2276,7 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
 #ifdef ENABLE_ALL_METRICS
     metrics_.invalid_fetch_res_pages_msg_++;
 #endif
-    return true;
+    return;
   }
 
   // if msg is not relevant
@@ -2284,7 +2285,7 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
 #ifdef ENABLE_ALL_METRICS
     metrics_.irrelevant_fetch_res_pages_msg_++;
 #endif
-    return true;
+    return;
   }
 
   FetchingState fetchingState = getFetchingState();
@@ -2304,7 +2305,7 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
     metrics_.sent_reject_fetch_msg_++;
     replicaForStateTransfer_->sendStateTransferMessage(
         reinterpret_cast<char *>(&outMsg), sizeof(RejectFetchingMsg), replicaId);
-    return true;
+    return;
   }
 
   // find virtual block
@@ -2348,7 +2349,7 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
   // if msg is invalid (because lastKnownChunk+1 does not exist)
   if (nextChunk > numOfChunksInVBlock) {
     LOG_WARN(logger_, "Msg is invalid: illegal chunk number: " << KVLOG(replicaId, nextChunk, numOfChunksInVBlock));
-    return true;
+    return;
   }
 
   // send chunks
@@ -2359,13 +2360,12 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
     ConcordAssertGT(chunkSize, 0);
 
     char *pRawChunk = vblock + (nextChunk - 1) * config_.maxChunkSize;
-    ItemDataMsg *outMsg = ItemDataMsg::alloc(chunkSize);
+    auto outMsg = ItemDataMsg::alloc(chunkSize);
 
     outMsg->requestMsgSeqNum = m->msgSeqNum;
     outMsg->blockNumber = ID_OF_VBLOCK_RES_PAGES;
     outMsg->totalNumberOfChunksInBlock = numOfChunksInVBlock;
     outMsg->chunkNumber = nextChunk;
-    outMsg->dataSize = chunkSize;
     outMsg->lastInBatch =
         ((numOfSentChunks + 1) >= config_.maxNumberOfChunksInBatch || (nextChunk == numOfChunksInVBlock));
     memcpy(outMsg->data, pRawChunk, chunkSize);
@@ -2377,13 +2377,13 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
                                                outMsg->blockNumber,
                                                outMsg->totalNumberOfChunksInBlock,
                                                outMsg->chunkNumber,
-                                               outMsg->dataSize,
+                                               outMsg->getDataSize(),
+                                               outMsg->rvbDigestsSize,
                                                (bool)outMsg->lastInBatch));
     metrics_.sent_item_data_msg_++;
 
-    replicaForStateTransfer_->sendStateTransferMessage(reinterpret_cast<char *>(outMsg), outMsg->size(), replicaId);
+    replicaForStateTransfer_->sendStateTransferMessage(outMsg.getSerializedMsg(), outMsg->size(), replicaId);
 
-    ItemDataMsg::free(outMsg);
     numOfSentChunks++;
 
     // if we've already sent enough chunks
@@ -2399,10 +2399,10 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
       break;
     }
   }
-  return true;
+  return;
 }
 
-bool BCStateTran::onMessage(const RejectFetchingMsg *m, uint32_t msgLen, uint16_t replicaId) {
+void BCStateTran::onMessage(STMessageUptr<RejectFetchingMsg> m, uint32_t msgLen, uint16_t replicaId) {
   LOG_DEBUG(logger_, KVLOG(replicaId, m->requestMsgSeqNum));
   metrics_.received_reject_fetching_msg_++;
 
@@ -2410,21 +2410,21 @@ bool BCStateTran::onMessage(const RejectFetchingMsg *m, uint32_t msgLen, uint16_
   if (fs != FetchingState::GettingMissingBlocks && fs != FetchingState::GettingMissingResPages) {
     LOG_ERROR(logger_,
               "Expected Fetching State GettingMissingBlocks or GettingMissingResPages. Got: " << stateName(fs));
-    return true;
+    return;
   }
 
   // if msg is invalid
   if (msgLen < sizeof(RejectFetchingMsg)) {
     LOG_WARN(logger_, "Msg is invalid: " << KVLOG(replicaId, msgLen));
     metrics_.invalid_reject_fetching_msg_++;
-    return true;
+    return;
   }
 
   auto itr = m->reasonMessages.find(m->rejectionCode);
   if (itr == m->reasonMessages.end()) {
     LOG_WARN(logger_, "Msg is invalid: " << KVLOG(replicaId, m->rejectionCode));
     metrics_.invalid_reject_fetching_msg_++;
-    return true;
+    return;
   }
 
   // if msg is not relevant
@@ -2443,7 +2443,7 @@ bool BCStateTran::onMessage(const RejectFetchingMsg *m, uint32_t msgLen, uint16_
 #ifdef ENABLE_ALL_METRICS
     metrics_.irrelevant_reject_fetching_msg_++;
 #endif
-    return true;
+    return;
   }
 
   LOG_INFO(
@@ -2464,11 +2464,11 @@ bool BCStateTran::onMessage(const RejectFetchingMsg *m, uint32_t msgLen, uint16_
     clearAllPendingItemsData();
     processData();
   }
-  return true;
+  return;
 }
 
 // Retrieve either a chunk of a block or a reserved page when fetching
-bool BCStateTran::onMessage(const ItemDataMsg *m,
+void BCStateTran::onMessage(STMessageUptr<ItemDataMsg> m,
                             uint32_t msgLen,
                             uint16_t replicaId,
                             LocalTimePoint incomingEventsQPushTime) {
@@ -2479,44 +2479,50 @@ bool BCStateTran::onMessage(const ItemDataMsg *m,
   if ((fs != FetchingState::GettingMissingBlocks) && (fs != FetchingState::GettingMissingResPages)) {
     LOG_ERROR(logger_,
               "Expected Fetching State GettingMissingBlocks or GettingMissingResPages. Got: " << stateName(fs));
-    return true;
+    return;
   }
 
   if (!sourceSelector_.isValidSourceId(replicaId)) {
     LOG_ERROR(logger_, "Msg received from invalid source " << replicaId);
-    return true;
+    return;
   }
 
   const auto MaxNumOfChunksInBlock =
       (fs == FetchingState::GettingMissingBlocks) ? maxNumOfChunksInAppBlock_ : maxNumOfChunksInVBlock_;
 
+  // The following fields of m are used after m is moved. copy them here to allow using them later.
+  auto msgRequestSeqNum = m->requestMsgSeqNum;
+  auto msgRvbDigestsSize = m->rvbDigestsSize;
+  auto msgDataSize = m->getDataSize();
+  auto msgLastInBatch = m->lastInBatch;
+
   LOG_DEBUG(logger_,
             std::boolalpha << KVLOG(replicaId,
-                                    m->requestMsgSeqNum,
+                                    msgRequestSeqNum,
                                     m->blockNumber,
                                     m->totalNumberOfChunksInBlock,
                                     m->chunkNumber,
-                                    m->dataSize,
-                                    (bool)m->lastInBatch,
-                                    m->rvbDigestsSize));
+                                    msgDataSize,
+                                    (bool)msgLastInBatch,
+                                    msgRvbDigestsSize));
 
   // if msg is invalid
-  if ((msgLen != m->size()) || (m->requestMsgSeqNum == 0) || (m->blockNumber == 0) ||
+  if ((msgLen != m->size()) || (msgRequestSeqNum == 0) || (m->blockNumber == 0) ||
       (m->totalNumberOfChunksInBlock == 0) || (m->totalNumberOfChunksInBlock > MaxNumOfChunksInBlock) ||
-      (m->chunkNumber == 0) || (m->dataSize == 0) || (m->rvbDigestsSize >= m->dataSize)) {
+      (m->chunkNumber == 0) || (msgDataSize == 0) || (msgRvbDigestsSize >= msgDataSize)) {
     LOG_WARN(logger_,
              "Msg is invalid: " << KVLOG(replicaId,
                                          msgLen,
                                          m->size(),
-                                         m->requestMsgSeqNum,
+                                         msgRequestSeqNum,
                                          m->blockNumber,
                                          m->totalNumberOfChunksInBlock,
                                          MaxNumOfChunksInBlock,
                                          m->chunkNumber,
-                                         m->rvbDigestsSize,
-                                         m->dataSize));
+                                         msgRvbDigestsSize,
+                                         msgDataSize));
     metrics_.invalid_item_data_msg_++;
-    return true;
+    return;
   }
 
   auto fetchingState = fs;
@@ -2529,49 +2535,49 @@ bool BCStateTran::onMessage(const ItemDataMsg *m,
     // delayed due to retransmissions, but it should still be valid block with an expected ID. No reason to drop.
     if ((sourceSelector_.currentReplica() != replicaId) || (fetchState_.minBlockId > m->blockNumber) ||
         (fetchState_.nextBlockId < m->blockNumber) ||
-        (m->dataSize + totalSizeOfPendingItemDataMsgs > config_.maxPendingDataFromSourceReplica)) {
+        (msgDataSize + totalSizeOfPendingItemDataMsgs > config_.maxPendingDataFromSourceReplica)) {
       LOG_WARN(logger_,
                "Msg is irrelevant: " << KVLOG(replicaId,
                                               fetchingState,
                                               sourceSelector_.currentReplica(),
-                                              m->requestMsgSeqNum,
+                                              msgRequestSeqNum,
                                               lastMsgSeqNum_,
                                               m->blockNumber,
                                               fetchState_,
                                               config_.maxNumberOfChunksInBatch,
-                                              m->rvbDigestsSize,
-                                              m->dataSize,
+                                              msgRvbDigestsSize,
+                                              msgDataSize,
                                               totalSizeOfPendingItemDataMsgs,
                                               config_.maxPendingDataFromSourceReplica));
       metrics_.irrelevant_item_data_msg_++;
-      return true;
+      return;
     }
   } else {
     ConcordAssertEQ(psd_->getFirstRequiredBlock(), 0);
     ConcordAssertEQ(psd_->getLastRequiredBlock(), 0);
 
-    if ((sourceSelector_.currentReplica() != replicaId) || (m->requestMsgSeqNum != lastMsgSeqNum_) ||
+    if ((sourceSelector_.currentReplica() != replicaId) || (msgRequestSeqNum != lastMsgSeqNum_) ||
         (m->blockNumber != ID_OF_VBLOCK_RES_PAGES) ||
-        (m->dataSize + totalSizeOfPendingItemDataMsgs > config_.maxPendingDataFromSourceReplica) ||
-        (m->rvbDigestsSize > 0)) {
+        (msgDataSize + totalSizeOfPendingItemDataMsgs > config_.maxPendingDataFromSourceReplica) ||
+        (msgRvbDigestsSize > 0)) {
       LOG_WARN(logger_,
                "Msg is irrelevant: " << KVLOG(replicaId,
                                               fetchingState,
                                               sourceSelector_.currentReplica(),
-                                              m->requestMsgSeqNum,
+                                              msgRequestSeqNum,
                                               lastMsgSeqNum_,
                                               (m->blockNumber == ID_OF_VBLOCK_RES_PAGES),
-                                              m->rvbDigestsSize,
-                                              m->dataSize,
+                                              msgRvbDigestsSize,
+                                              msgDataSize,
                                               totalSizeOfPendingItemDataMsgs,
                                               config_.maxPendingDataFromSourceReplica));
       metrics_.irrelevant_item_data_msg_++;
-      return true;
+      return;
     }
   }
 
   bool added = false;
-  tie(std::ignore, added) = pendingItemDataMsgs.insert(const_cast<ItemDataMsg *>(m));
+  tie(std::ignore, added) = pendingItemDataMsgs.emplace(std::move(m));
 
   // Log time spent in handoff queue
   auto fetchingTimeStamp = getMonotonicTimeMilli();
@@ -2588,19 +2594,18 @@ bool BCStateTran::onMessage(const ItemDataMsg *m,
 
   if (added) {
     LOG_DEBUG(logger_,
-              "ItemDataMsg was added to pendingItemDataMsgs: " << KVLOG(replicaId, fetchingState, m->requestMsgSeqNum));
+              "ItemDataMsg was added to pendingItemDataMsgs: " << KVLOG(replicaId, fetchingState, msgRequestSeqNum));
 #ifdef ENABLE_ALL_METRICS
     metrics_.num_pending_item_data_msgs_.Get().Set(pendingItemDataMsgs.size());
 #endif
-    totalSizeOfPendingItemDataMsgs += m->dataSize;
+    totalSizeOfPendingItemDataMsgs += msgDataSize;
     metrics_.total_size_of_pending_item_data_msgs_.Get().Set(totalSizeOfPendingItemDataMsgs);
-    processData(m->lastInBatch, m->rvbDigestsSize);
-    return false;
+    processData(msgLastInBatch, msgRvbDigestsSize);
+    return;
   } else {
-    LOG_INFO(
-        logger_,
-        "ItemDataMsg was NOT added to pendingItemDataMsgs: " << KVLOG(replicaId, fetchingState, m->requestMsgSeqNum));
-    return true;
+    LOG_INFO(logger_,
+             "ItemDataMsg was NOT added to pendingItemDataMsgs: " << KVLOG(replicaId, fetchingState, msgRequestSeqNum));
+    return;
   }
 }
 
@@ -2713,12 +2718,6 @@ char *BCStateTran::createVBlock(const DescOfVBlockForResPages &desc) {
 void BCStateTran::clearInfoAboutGettingCheckpointSummary() {
   lastTimeSentAskForCheckpointSummariesMsg = 0;
   retransmissionNumberOfAskForCheckpointSummariesMsg = 0;
-
-  for (auto i : summariesCerts) {
-    i.second->resetAndFree();
-    delete i.second;
-  }
-
   summariesCerts.clear();
   numOfSummariesFromOtherReplicas.clear();
 }
@@ -2737,10 +2736,6 @@ void BCStateTran::verifyEmptyInfoAboutGettingCheckpointSummary() {
 void BCStateTran::clearAllPendingItemsData() {
   LOG_DEBUG(logger_, "");
 
-  for (auto i : pendingItemDataMsgs) {
-    replicaForStateTransfer_->freeStateTransferMsg(reinterpret_cast<char *>(i));
-  }
-
   pendingItemDataMsgs.clear();
   totalSizeOfPendingItemDataMsgs = 0;
 #ifdef ENABLE_ALL_METRICS
@@ -2756,11 +2751,10 @@ void BCStateTran::clearPendingItemsData(uint64_t fromBlock, uint64_t untilBlock)
 
   auto it = pendingItemDataMsgs.begin();
   while (it != pendingItemDataMsgs.end()) {
-    ConcordAssertGE(totalSizeOfPendingItemDataMsgs, (*it)->dataSize);
+    ConcordAssertGE(totalSizeOfPendingItemDataMsgs, (*it)->getDataSize());
 
     if (((*it)->blockNumber >= fromBlock) && ((*it)->blockNumber <= untilBlock)) {
-      totalSizeOfPendingItemDataMsgs -= (*it)->dataSize;
-      replicaForStateTransfer_->freeStateTransferMsg(reinterpret_cast<char *>(*it));
+      totalSizeOfPendingItemDataMsgs -= (*it)->getDataSize();
       it = pendingItemDataMsgs.erase(it);
     }
     ++it;
@@ -2790,15 +2784,15 @@ bool BCStateTran::getNextFullBlock(uint64_t requiredBlock,
   uint16_t maxAvailableChunk = 0;
   uint32_t blockSize = 0;
 
-  auto it = pendingItemDataMsgs.begin();
-  while ((it != pendingItemDataMsgs.end()) && ((*it)->blockNumber == requiredBlock)) {
-    ItemDataMsg *msg = *it;
-
+  for (const auto &msg : pendingItemDataMsgs) {
+    if (msg->blockNumber != requiredBlock) {
+      break;
+    }
     // the conditions of these asserts are checked when receiving the message
     ConcordAssertGT(msg->totalNumberOfChunksInBlock, 0);
     ConcordAssertGE(msg->chunkNumber, 1);
     if (totalNumberOfChunks == 0) totalNumberOfChunks = msg->totalNumberOfChunksInBlock;
-    blockSize += (msg->dataSize - msg->rvbDigestsSize);
+    blockSize += (msg->getDataSize() - msg->rvbDigestsSize);
     if (totalNumberOfChunks != msg->totalNumberOfChunksInBlock || msg->chunkNumber > totalNumberOfChunks ||
         blockSize > maxSize) {
       badData = true;
@@ -2815,8 +2809,7 @@ bool BCStateTran::getNextFullBlock(uint64_t requiredBlock,
       fullBlock = true;
       break;
     }
-    ++it;
-  }  // while
+  }
 
   if (badData) {
     ConcordAssert(!fullBlock);
@@ -2834,23 +2827,21 @@ bool BCStateTran::getNextFullBlock(uint64_t requiredBlock,
   uint16_t currentChunk = 0;
   uint32_t currentPos = 0;
 
-  it = pendingItemDataMsgs.begin();
+  auto it = pendingItemDataMsgs.begin();
   while (true) {
     ConcordAssertNE(it, pendingItemDataMsgs.end());
-    ConcordAssertEQ((*it)->blockNumber, requiredBlock);
+    auto &msg = *it;
 
-    ItemDataMsg *msg = *it;
-
+    ConcordAssertEQ(msg->blockNumber, requiredBlock);
     ConcordAssertGE(msg->chunkNumber, 1);
     ConcordAssertEQ(msg->totalNumberOfChunksInBlock, totalNumberOfChunks);
     ConcordAssertEQ(currentChunk + 1, msg->chunkNumber);
-    ConcordAssertLE(currentPos + msg->dataSize - msg->rvbDigestsSize, maxSize);
+    ConcordAssertLE(currentPos + msg->getDataSize() - msg->rvbDigestsSize, maxSize);
 
-    memcpy(outBlock + currentPos, msg->data, msg->dataSize);
+    memcpy(outBlock + currentPos, msg->data, msg->getDataSize());
     currentChunk = msg->chunkNumber;
-    currentPos += msg->dataSize;
-    totalSizeOfPendingItemDataMsgs -= (*it)->dataSize;
-    replicaForStateTransfer_->freeStateTransferMsg(reinterpret_cast<char *>(*it));
+    currentPos += msg->getDataSize();
+    totalSizeOfPendingItemDataMsgs -= msg->getDataSize();
     it = pendingItemDataMsgs.erase(it);
 #ifdef ENABLE_ALL_METRICS
     metrics_.num_pending_item_data_msgs_.Get().Set(pendingItemDataMsgs.size());
@@ -3277,9 +3268,6 @@ void BCStateTran::stReset(DataStoreTransaction *txn, bool resetRvbm, bool resetS
   cacheOfVirtualBlockForResPages.clear();
   lastTimeSentAskForCheckpointSummariesMsg = 0;
   retransmissionNumberOfAskForCheckpointSummariesMsg = 0;
-  for (auto i : summariesCerts) {
-    replicaForStateTransfer_->freeStateTransferMsg(reinterpret_cast<char *>(i.second));
-  }
   summariesCerts.clear();
   numOfSummariesFromOtherReplicas.clear();
   clearIoContexts();
@@ -3594,13 +3582,13 @@ void BCStateTran::processData(bool lastInBatch, uint32_t rvbDigestsSize) {
         // Report Completion to 3rd parties. At this point ST moves to the next and final state, while asynchronously
         // for all callbacks to finish in a worker thead context.
         on_transferring_complete_ongoing_ = true;
-        auto fs = getFetchingState();
+        auto currentFs = getFetchingState();
         LOG_INFO(
             logger_,
             "Invoking onTransferringComplete callbacks (asynchronously):"
                 << std::boolalpha
                 << KVLOG(on_transferring_complete_ongoing_, targetCheckpointDesc_.checkpointNum, getFetchingState()));
-        ConcordAssertEQ(fs, FetchingState::FinalizingCycle);
+        ConcordAssertEQ(currentFs, FetchingState::FinalizingCycle);
         ConcordAssert(psd_->getIsFetchingState());
         on_transferring_complete_future_ = std::async(std::launch::async, [this]() {
           auto size = on_transferring_complete_cb_registry_.size();

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -42,6 +42,7 @@
 #include "TimeUtils.hpp"
 #include "SimpleMemoryPool.hpp"
 #include "messages/MessageBase.hpp"
+#include "memory.hpp"
 
 using std::set;
 using std::map;
@@ -349,13 +350,27 @@ class BCStateTran : public IStateTransfer {
   // Message handlers
   ///////////////////////////////////////////////////////////////////////////
 
+  template <typename MSG>
+  static void freeStateTransferMsg(const MSG* m);
+
+  template <typename T>
+  using STMessageUptr = custom_deleter_unique_ptr<const T, freeStateTransferMsg<T>>;
+
+  template <typename T>
+  STMessageUptr<T> convertBaseStMsgToRealStMsgType(const BCStateTranBaseMsg* msgHeader) {
+    return STMessageUptr<T>(reinterpret_cast<const T*>(msgHeader));
+  }
+
   inline std::string getScopedMdcStr(uint16_t replicaId, uint64_t seqNum, uint16_t = 0, uint64_t = 0);
-  bool onMessage(const AskForCheckpointSummariesMsg* m, uint32_t msgLen, uint16_t replicaId);
-  bool onMessage(const CheckpointSummaryMsg* m, uint32_t msgLen, uint16_t replicaId);
-  bool onMessage(const FetchBlocksMsg* m, uint32_t msgLen, uint16_t replicaId);
-  bool onMessage(const FetchResPagesMsg* m, uint32_t msgLen, uint16_t replicaId);
-  bool onMessage(const RejectFetchingMsg* m, uint32_t msgLen, uint16_t replicaId);
-  bool onMessage(const ItemDataMsg* m, uint32_t msgLen, uint16_t replicaId, LocalTimePoint incomingEventsQPushTime);
+  void onMessage(STMessageUptr<AskForCheckpointSummariesMsg> m, uint32_t msgLen, uint16_t replicaId);
+  void onMessage(STMessageUptr<CheckpointSummaryMsg> m, uint32_t msgLen, uint16_t replicaId);
+  void onMessage(STMessageUptr<FetchBlocksMsg> m, uint32_t msgLen, uint16_t replicaId);
+  void onMessage(STMessageUptr<FetchResPagesMsg> m, uint32_t msgLen, uint16_t replicaId);
+  void onMessage(STMessageUptr<RejectFetchingMsg> m, uint32_t msgLen, uint16_t replicaId);
+  void onMessage(STMessageUptr<ItemDataMsg> m,
+                 uint32_t msgLen,
+                 uint16_t replicaId,
+                 LocalTimePoint incomingEventsQPushTime);
 
   ///////////////////////////////////////////////////////////////////////////
   // cache that holds virtual blocks
@@ -391,8 +406,13 @@ class BCStateTran : public IStateTransfer {
 
   typedef MsgsCertificate<CheckpointSummaryMsg, false, false, true, CheckpointSummaryMsg> CheckpointSummaryMsgCert;
 
+  static void freeCheckpointSummariesCert(CheckpointSummaryMsgCert* c) {
+    c->resetAndFree();
+    delete c;
+  }
+  using CheckpointSummaryMsgCertUptr = custom_deleter_unique_ptr<CheckpointSummaryMsgCert, freeCheckpointSummariesCert>;
   // map from checkpointNum to CheckpointSummaryMsgCert
-  map<uint64_t, CheckpointSummaryMsgCert*> summariesCerts;
+  map<uint64_t, CheckpointSummaryMsgCertUptr> summariesCerts;
 
   // map from replica Id to number of accepted CheckpointSummaryMsg messages
   map<uint16_t, uint16_t> numOfSummariesFromOtherReplicas;
@@ -445,7 +465,7 @@ class BCStateTran : public IStateTransfer {
   inline uint64_t nextRvbBlockId(uint64_t block_id) const;
 
   struct compareItemDataMsg {
-    bool operator()(const ItemDataMsg* l, const ItemDataMsg* r) const {
+    bool operator()(STMessageUptr<ItemDataMsg> const& l, STMessageUptr<ItemDataMsg> const& r) const {
       if (l->blockNumber != r->blockNumber)
         return (l->blockNumber > r->blockNumber);
       else
@@ -453,7 +473,7 @@ class BCStateTran : public IStateTransfer {
     }
   };
 
-  set<ItemDataMsg*, compareItemDataMsg> pendingItemDataMsgs;
+  set<STMessageUptr<ItemDataMsg>, compareItemDataMsg> pendingItemDataMsgs;
   uint32_t totalSizeOfPendingItemDataMsgs = 0;
 
   void stReset(DataStoreTransaction* txn,

--- a/bftengine/src/bcstatetransfer/Messages.hpp
+++ b/bftengine/src/bcstatetransfer/Messages.hpp
@@ -40,14 +40,32 @@ class MsgType {
 };
 
 struct BCStateTranBaseMsg {
+  BCStateTranBaseMsg(uint16_t type) : type(type) {}
   uint16_t type;
+  // This struct and its derived structs are used to de/serialize message buffers sent over communication channels.
+  // Since virtual methods modify the memory layout of a struct, there cannot be any for both this base struct and its
+  // inheritors.
+};
+
+// VariableSizeMsg is useful for structs with a flexible array member
+template <typename T>
+class VariableSizeMsg {
+ public:
+  VariableSizeMsg(size_t dataSize) : buffer_(new concord::Byte[calcMsgSize(dataSize)]()) {}
+
+  T* operator->() const { return reinterpret_cast<T*>(buffer_.get()); }
+
+  char* getSerializedMsg() const { return reinterpret_cast<char*>(buffer_.get()); }
+
+  static size_t calcMsgSize(size_t dataSize) { return sizeof(T) - 1 + dataSize; }
+
+ private:
+  std::unique_ptr<concord::Byte[]> buffer_;
 };
 
 struct AskForCheckpointSummariesMsg : public BCStateTranBaseMsg {
-  AskForCheckpointSummariesMsg() {
-    memset(this, 0, sizeof(AskForCheckpointSummariesMsg));
-    type = MsgType::AskForCheckpointSummaries;
-  }
+  AskForCheckpointSummariesMsg()
+      : BCStateTranBaseMsg{MsgType::AskForCheckpointSummaries}, msgSeqNum{}, minRelevantCheckpointNum{} {}
 
   uint64_t msgSeqNum;
   uint64_t minRelevantCheckpointNum;
@@ -56,31 +74,11 @@ struct AskForCheckpointSummariesMsg : public BCStateTranBaseMsg {
 struct CheckpointSummaryMsg : public BCStateTranBaseMsg {
   CheckpointSummaryMsg() = delete;
 
-  static CheckpointSummaryMsg* alloc(size_t rvbDataSize) {
-    size_t totalByteSize = sizeof(CheckpointSummaryMsg) + rvbDataSize - 1;
-    CheckpointSummaryMsg* msg{static_cast<CheckpointSummaryMsg*>(std::malloc(totalByteSize))};
-    if (!msg) {
-      throw std::bad_alloc();
-    }
-    memset(msg, 0, totalByteSize);
+  static VariableSizeMsg<CheckpointSummaryMsg> alloc(size_t rvbDataSize) {
+    VariableSizeMsg<CheckpointSummaryMsg> msg{rvbDataSize};
     msg->type = MsgType::CheckpointsSummary;
     msg->rvbDataSize = rvbDataSize;
     return msg;
-  }
-
-  static CheckpointSummaryMsg* alloc(const CheckpointSummaryMsg* rMsg) {
-    auto msg = alloc(rMsg->rvbDataSize);
-    msg->checkpointNum = rMsg->checkpointNum;
-    msg->maxBlockId = rMsg->maxBlockId;
-    msg->digestOfMaxBlockId = rMsg->digestOfMaxBlockId;
-    msg->digestOfResPagesDescriptor = rMsg->digestOfResPagesDescriptor;
-    msg->requestMsgSeqNum = rMsg->requestMsgSeqNum;
-    memcpy(msg->data, rMsg->data, rMsg->rvbDataSize);
-    return msg;
-  }
-
-  static void free(const CheckpointSummaryMsg* msg) {
-    std::free(const_cast<char*>(reinterpret_cast<const char*>(msg)));
   }
 
   static void free(void* context, const CheckpointSummaryMsg* msg) {
@@ -88,7 +86,7 @@ struct CheckpointSummaryMsg : public BCStateTranBaseMsg {
     rep->freeStateTransferMsg(const_cast<char*>(reinterpret_cast<const char*>(msg)));
   }
 
-  size_t size() const { return sizeof(CheckpointSummaryMsg) + rvbDataSize - 1; }
+  size_t size() const { return VariableSizeMsg<CheckpointSummaryMsg>::calcMsgSize(rvbDataSize); }
   size_t sizeofRvbData() const { return rvbDataSize; }
 
   uint64_t checkpointNum;
@@ -168,10 +166,14 @@ struct CheckpointSummaryMsg : public BCStateTranBaseMsg {
 };
 
 struct FetchBlocksMsg : public BCStateTranBaseMsg {
-  FetchBlocksMsg() {
-    memset(this, 0, sizeof(FetchBlocksMsg));
-    type = MsgType::FetchBlocks;
-  }
+  FetchBlocksMsg()
+      : BCStateTranBaseMsg{MsgType::FetchBlocks},
+        msgSeqNum{},
+        minBlockId{},
+        maxBlockId{},
+        maxBlockIdInCycle{},
+        rvbGroupId{},
+        lastKnownChunkInLastRequiredBlock{} {}
 
   uint64_t msgSeqNum;
   uint64_t minBlockId;
@@ -182,10 +184,12 @@ struct FetchBlocksMsg : public BCStateTranBaseMsg {
 };
 
 struct FetchResPagesMsg : public BCStateTranBaseMsg {
-  FetchResPagesMsg() {
-    memset(this, 0, sizeof(FetchResPagesMsg));
-    type = MsgType::FetchResPages;
-  }
+  FetchResPagesMsg()
+      : BCStateTranBaseMsg{MsgType::FetchResPages},
+        msgSeqNum{},
+        lastCheckpointKnownToRequester{},
+        requiredCheckpointNum{},
+        lastKnownChunk{} {}
 
   uint64_t msgSeqNum;
   uint64_t lastCheckpointKnownToRequester;
@@ -211,12 +215,8 @@ struct RejectFetchingMsg : public BCStateTranBaseMsg {
     };
   };
   RejectFetchingMsg() = delete;
-  RejectFetchingMsg(uint16_t rejCode, uint64_t reqMsgSeqNum) {
-    memset(this, 0, sizeof(RejectFetchingMsg));
-    type = MsgType::RejectFetching;
-    rejectionCode = rejCode;
-    requestMsgSeqNum = reqMsgSeqNum;
-  }
+  RejectFetchingMsg(uint16_t rejCode, uint64_t reqMsgSeqNum)
+      : BCStateTranBaseMsg{MsgType::RejectFetching}, requestMsgSeqNum{reqMsgSeqNum}, rejectionCode{rejCode} {}
 
   uint64_t requestMsgSeqNum;
   uint16_t rejectionCode;
@@ -232,31 +232,30 @@ struct RejectFetchingMsg : public BCStateTranBaseMsg {
 };
 
 struct ItemDataMsg : public BCStateTranBaseMsg {
-  static ItemDataMsg* alloc(uint32_t dataSize) {
-    size_t msgSize = sizeof(ItemDataMsg) - 1 + dataSize;
-    ItemDataMsg* msg = static_cast<ItemDataMsg*>(std::malloc(msgSize));
-    if (!msg) {
-      throw std::bad_alloc();
-    }
-    memset(msg, 0, msgSize);
+  ItemDataMsg() = delete;
+
+  static VariableSizeMsg<ItemDataMsg> alloc(size_t dataSize) {
+    VariableSizeMsg<ItemDataMsg> msg{dataSize};
     msg->type = MsgType::ItemData;
     msg->dataSize = dataSize;
     return msg;
   }
 
-  static void free(ItemDataMsg* msg) { std::free(msg); }
-
   uint64_t requestMsgSeqNum;
   uint64_t blockNumber;
   uint16_t totalNumberOfChunksInBlock;
   uint16_t chunkNumber;
-  uint32_t dataSize;
   uint8_t lastInBatch;
   uint32_t rvbDigestsSize;  // if non-zero, size in bytes  which is dedicated to RVB
                             // digests from the total of dataSize (rvbDigestsSize < dataSize)
-  char data[1];             // MSB[raw block of size dataSize-rvbDigestsSize|RVB DIGESTS of size rvbDigestsSize]LSB
+ private:
+  uint32_t dataSize;
 
-  uint32_t size() const { return sizeof(ItemDataMsg) - 1 + dataSize; }
+ public:
+  char data[1];  // MSB[raw block of size dataSize-rvbDigestsSize|RVB DIGESTS of size rvbDigestsSize]LSB
+
+  uint32_t size() const { return VariableSizeMsg<ItemDataMsg>::calcMsgSize(dataSize); }
+  uint32_t getDataSize() const { return dataSize; }
 };
 
 #pragma pack(pop)

--- a/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
+++ b/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
@@ -1076,7 +1076,7 @@ FakeSources::FakeSources(const Config& targetConfig,
 void FakeSources::replyAskForCheckpointSummariesMsg(bool generateBlocksAndDescriptors) {
   // We expect a source not fetching. Sending a reject message is not yet supported
   ASSERT_FALSE(datastore_->getIsFetchingState());
-  vector<CheckpointSummaryMsg*> checkpointSummaryReplies;
+  vector<VariableSizeMsg<CheckpointSummaryMsg>> checkpointSummaryReplies;
 
   if (generateBlocksAndDescriptors) {
     // Generate all the blocks until maxBlockId of the last checkpoint - set into appState_
@@ -1097,31 +1097,25 @@ void FakeSources::replyAskForCheckpointSummariesMsg(bool generateBlocksAndDescri
   for (uint64_t i = testState_.maxRepliedCheckpointNum; i >= testState_.minRepliedCheckpointNum; i--) {
     ASSERT_TRUE(datastore_->hasCheckpointDesc(i));
     DataStore::CheckpointDesc desc = datastore_->getCheckpointDesc(i);
-    CheckpointSummaryMsg* reply(CheckpointSummaryMsg::alloc(desc.rvbData.size()));
-    ASSERT_TRUE(reply);
+    auto reply(CheckpointSummaryMsg::alloc(desc.rvbData.size()));
     reply->checkpointNum = desc.checkpointNum;
     reply->maxBlockId = desc.maxBlockId;
     reply->digestOfMaxBlockId = desc.digestOfMaxBlockId;
     reply->digestOfResPagesDescriptor = desc.digestOfResPagesDescriptor;
     reply->requestMsgSeqNum = firstAskForCheckpointSummariesMsg->msgSeqNum;
     std::copy(desc.rvbData.begin(), desc.rvbData.end(), reply->data);
-    checkpointSummaryReplies.push_back(reply);
+    checkpointSummaryReplies.push_back(std::move(reply));
   }
 
   // send replies from all replicas (shuffle the requests to get a random reply order)
   auto rng = std::default_random_engine{};
   std::shuffle(std::begin(testedReplicaIf_.sent_messages_), std::end(testedReplicaIf_.sent_messages_), rng);
-  for (const auto reply : checkpointSummaryReplies) {
+  for (const auto& reply : checkpointSummaryReplies) {
     for (auto& request : testedReplicaIf_.sent_messages_) {
-      CheckpointSummaryMsg* uniqueReply = CheckpointSummaryMsg::alloc(reply);
-      ASSERT_TRUE(uniqueReply);
       char* msgBytes{nullptr};
-      ASSERT_NFF(
-          TestUtils::allocCopyStateTransferMsg(reinterpret_cast<char*>(uniqueReply), uniqueReply->size(), &msgBytes));
-      stDelegator_->handleStateTransferMessage(reinterpret_cast<char*>(msgBytes), uniqueReply->size(), request.to_);
-      CheckpointSummaryMsg::free(uniqueReply);
+      ASSERT_NFF(TestUtils::allocCopyStateTransferMsg(reply.getSerializedMsg(), reply->size(), &msgBytes));
+      stDelegator_->handleStateTransferMessage(reinterpret_cast<char*>(msgBytes), reply->size(), request.to_);
     }
-    CheckpointSummaryMsg::free(reply);
   }
   ASSERT_EQ(clearSentMessagesByMessageType(MsgType::AskForCheckpointSummaries), targetConfig_.numReplicas - 1);
 }
@@ -1151,8 +1145,7 @@ void FakeSources::replyFetchBlocksMsg() {
   while (true) {
     size_t rvbGroupDigestsActualSize{0};
     auto blk = appState_.peekBlock(nextBlockId);
-    ItemDataMsg* itemDataMsg = ItemDataMsg::alloc(blk->totalBlockSize + rvbGroupDigestsExpectedSize);
-    ASSERT_TRUE(itemDataMsg);
+    auto itemDataMsg = ItemDataMsg::alloc(blk->totalBlockSize + rvbGroupDigestsExpectedSize);
     bool lastInBatch = ((numOfSentChunks + 1) >= targetConfig_.maxNumberOfChunksInBatch) ||
                        ((nextBlockId - 1) < fetchBlocksMsg->minBlockId);
     itemDataMsg->lastInBatch = lastInBatch;
@@ -1168,14 +1161,11 @@ void FakeSources::replyFetchBlocksMsg() {
       ConcordAssertLE(rvbGroupDigestsActualSize, rvbGroupDigestsActualSize);
       rvbGroupDigestsExpectedSize = 0;
     }
-    itemDataMsg->dataSize = blk->totalBlockSize + rvbGroupDigestsActualSize;
     itemDataMsg->rvbDigestsSize = rvbGroupDigestsActualSize;
     memcpy(itemDataMsg->data + rvbGroupDigestsActualSize, blk.get(), blk->totalBlockSize);
     char* msgBytes{nullptr};
-    ASSERT_NFF(
-        TestUtils::allocCopyStateTransferMsg(reinterpret_cast<char*>(itemDataMsg), itemDataMsg->size(), &msgBytes));
+    ASSERT_NFF(TestUtils::allocCopyStateTransferMsg(itemDataMsg.getSerializedMsg(), itemDataMsg->size(), &msgBytes));
     stDelegator_->handleStateTransferMessage(reinterpret_cast<char*>(msgBytes), itemDataMsg->size(), msg.to_);
-    ItemDataMsg::free(itemDataMsg);
     if (lastInBatch) {
       break;
     }
@@ -1250,23 +1240,19 @@ void FakeSources::replyResPagesMsg(bool& outDoneSending) {
     ASSERT_GT(chunkSize, 0);
 
     char* pRawChunk = rawVBlock_.get() + (nextChunk - 1) * targetConfig_.maxChunkSize;
-    ItemDataMsg* itemDataMsg = ItemDataMsg::alloc(chunkSize);
-    ASSERT_TRUE(itemDataMsg);
+    auto itemDataMsg = ItemDataMsg::alloc(chunkSize);
 
     itemDataMsg->requestMsgSeqNum = fetchResPagesMsg->msgSeqNum;
     itemDataMsg->blockNumber = BcStTestDelegator::ID_OF_VBLOCK_RES_PAGES;
     itemDataMsg->totalNumberOfChunksInBlock = numOfChunksInVBlock;
     itemDataMsg->chunkNumber = nextChunk;
-    itemDataMsg->dataSize = chunkSize;
     itemDataMsg->lastInBatch =
         ((numOfSentChunks + 1) >= targetConfig_.maxNumberOfChunksInBatch || (nextChunk == numOfChunksInVBlock));
     memcpy(itemDataMsg->data, pRawChunk, chunkSize);
 
     char* msgBytes{nullptr};
-    ASSERT_NFF(
-        TestUtils::allocCopyStateTransferMsg(reinterpret_cast<char*>(itemDataMsg), itemDataMsg->size(), &msgBytes));
+    ASSERT_NFF(TestUtils::allocCopyStateTransferMsg(itemDataMsg.getSerializedMsg(), itemDataMsg->size(), &msgBytes));
     stDelegator_->handleStateTransferMessage(reinterpret_cast<char*>(msgBytes), itemDataMsg->size(), msg.to_);
-    ItemDataMsg::free(itemDataMsg);
     numOfSentChunks++;
 
     // if we've already sent enough chunks
@@ -1472,16 +1458,16 @@ void BcStTest::srcAssertItemDataMsgBatchSentWithBlocks(uint64_t minExpectedBlock
     ASSERT_EQ(blk->blockId, currentBlockId);
     // just compare the blocks, dont validate digests.
     if (itemDataMsg->rvbDigestsSize > 0) {
-      ASSERT_GT(itemDataMsg->dataSize, itemDataMsg->rvbDigestsSize);
-      ASSERT_EQ(blk->totalBlockSize, itemDataMsg->dataSize - itemDataMsg->rvbDigestsSize);
+      ASSERT_GT(itemDataMsg->getDataSize(), itemDataMsg->rvbDigestsSize);
+      ASSERT_EQ(blk->totalBlockSize, itemDataMsg->getDataSize() - itemDataMsg->rvbDigestsSize);
       ASSERT_EQ(memcmp(reinterpret_cast<char*>(blk.get()),
                        itemDataMsg->data + itemDataMsg->rvbDigestsSize,
-                       itemDataMsg->dataSize - itemDataMsg->rvbDigestsSize),
+                       itemDataMsg->getDataSize() - itemDataMsg->rvbDigestsSize),
                 0);
       // TODO - add here check for the RVB data. Need to get RVB group id from fake dest?
     } else {
-      ASSERT_EQ(blk->totalBlockSize, itemDataMsg->dataSize);
-      ASSERT_EQ(memcmp(reinterpret_cast<char*>(blk.get()), itemDataMsg->data, itemDataMsg->dataSize), 0);
+      ASSERT_EQ(blk->totalBlockSize, itemDataMsg->getDataSize());
+      ASSERT_EQ(memcmp(reinterpret_cast<char*>(blk.get()), itemDataMsg->data, itemDataMsg->getDataSize()), 0);
     }
     --currentBlockId;
   }
@@ -3028,11 +3014,11 @@ TEST_F(BcStTest, bkpTestRvbDataConflictDetection) {
     ASSERT_TRUE(datastore_->hasCheckpointDesc(i));
 
     DataStore::CheckpointDesc desc = datastore_->getCheckpointDesc(i);
-    Digest stateDigest, reservedPagesDigest, rvbDataDigest;
+    Digest stateDigest, reservedPagesDigest, cpRvbDataDigest;
     uint64_t outBlockId;
 
     stateTransfer_->getDigestOfCheckpoint(
-        i, sizeof(Digest), outBlockId, stateDigest.content(), reservedPagesDigest.content(), rvbDataDigest.content());
+        i, sizeof(Digest), outBlockId, stateDigest.content(), reservedPagesDigest.content(), cpRvbDataDigest.content());
     ASSERT_EQ(desc.checkpointNum, i);
     ASSERT_EQ(desc.maxBlockId, outBlockId);
     ASSERT_TRUE(!memcmp(desc.digestOfMaxBlockId.content(), stateDigest.content(), sizeof(Digest)));
@@ -3041,7 +3027,7 @@ TEST_F(BcStTest, bkpTestRvbDataConflictDetection) {
     if (i == testState_.minRepliedCheckpointNum) {
       // first checkpoint has a default RVB
       const auto& defaultRvbDataDigest = stDelegator_->computeDefaultRvbDataDigest();
-      ASSERT_TRUE(!memcmp(defaultRvbDataDigest.content(), rvbDataDigest.content(), sizeof(Digest)));
+      ASSERT_TRUE(!memcmp(defaultRvbDataDigest.content(), cpRvbDataDigest.content(), sizeof(Digest)));
     } else {
       DigestGenerator digestCtx;
       Digest rvbDataDigest;

--- a/tests/apollo/test_skvbc_state_transfer.py
+++ b/tests/apollo/test_skvbc_state_transfer.py
@@ -348,7 +348,8 @@ class SkvbcStateTransferTest(ApolloTest):
                 bft_network.all_replicas(),
                 num_of_checkpoints_to_add=2,
                 verify_checkpoint_persistency=False,
-                assert_state_transfer_not_started=False)
+                assert_state_transfer_not_started=False,
+                expected_starting_checkpoint=i * 2)
 
             if i > 0 and i % 2 == 0:
                 await op.latest_pruneable_block()

--- a/tests/apollo/util/skvbc.py
+++ b/tests/apollo/util/skvbc.py
@@ -266,7 +266,8 @@ class SimpleKVBCProtocol:
             verify_checkpoint_persistency=True,
             assert_state_transfer_not_started=True,
             without_clients=None,
-            timeout=30):
+            timeout=30,
+            expected_starting_checkpoint=None):
         """
         A helper function used by tests to fill a window with data and then
         checkpoint it.
@@ -278,8 +279,12 @@ class SimpleKVBCProtocol:
         """
         with log.start_action(action_type="fill_and_wait_for_checkpoint"):
             client = self.bft_network.random_client(without_clients)
+            if expected_starting_checkpoint is not None:
+                expected_checkpoint_num = lambda cp: cp == expected_starting_checkpoint
+            else:
+                expected_checkpoint_num = None
             checkpoint_before = await self.bft_network.wait_for_checkpoint(
-                replica_id=random.choice(initial_nodes))
+                replica_id=random.choice(initial_nodes), expected_checkpoint_num=expected_checkpoint_num)
             # Write enough data to checkpoint and create a need for state transfer
             for i in range(1 + num_of_checkpoints_to_add * CHECKPOINT_SEQUENCES):
                 key = self.random_key()


### PR DESCRIPTION
* **Problem Overview**  
  Raw pointers were used for all incoming and out going state transfer messages.
Replaced with smart pointers.
Adjust ST unittests accordingly.
* **Testing Done**  
  Apollo, ASAN
