### PR TITLE
Convert PrePrepareMsg to smart pointer

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -627,8 +627,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   concord::util::CallbackRegistry<> stopCallbacks_;
 
   void addTimers();
-  void startConsensusProcess(PrePrepareMsg* pp, bool isCreatedEarlier);
-  void startConsensusProcess(PrePrepareMsg* pp);
+  void startConsensusProcess(PrePrepareMsgUPtr pp, bool isCreatedEarlier);
+  void startConsensusProcess(PrePrepareMsgUPtr pp);
   /**
    * Updates both seqNumInfo and slow_path metric
    * @param seqNumInfo

--- a/bftengine/src/bftengine/SeqNumInfo.hpp
+++ b/bftengine/src/bftengine/SeqNumInfo.hpp
@@ -38,10 +38,10 @@ class SeqNumInfo {
   void resetCommitSignatures(CommitPath cPath);
   void resetPrepareSignatures();
   void resetAndFree();  // TODO(GG): name
-  void getAndReset(PrePrepareMsg*& outPrePrepare, PrepareFullMsg*& outCombinedValidSignatureMsg);
+  std::pair<PrePrepareMsg*, PrepareFullMsg*> getAndReset();
 
-  bool addMsg(PrePrepareMsg* m, bool directAdd = false, bool isTimeCorrect = true);
-  bool addSelfMsg(PrePrepareMsg* m, bool directAdd = false);
+  bool addMsg(PrePrepareMsgUPtr m, bool directAdd = false, bool isTimeCorrect = true);
+  bool addSelfMsg(PrePrepareMsgUPtr m, bool directAdd = false);
 
   bool addMsg(PreparePartialMsg* m);
   bool addSelfMsg(PreparePartialMsg* m, bool directAdd = false);
@@ -243,7 +243,7 @@ class SeqNumInfo {
 
   InternalReplicaApi* replica = nullptr;
 
-  PrePrepareMsg* prePrepareMsg;
+  PrePrepareMsgUPtr prePrepareMsg;
 
   // Slow path
   CollectorOfThresholdSignatures<PreparePartialMsg, PrepareFullMsg, ExFuncForPrepareCollector>* prepareSigCollector;


### PR DESCRIPTION
Convert PrePrepareMsg raw pointer to smart in:
- ReplicaImp::onMessage<PrePrepareMsg>()
- startConsensusProcess().

Tested: Apollo, maestro, ASAN