### PR TITLE
add incoming messages buffers allocations and releases monitor:

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -1139,6 +1139,9 @@ void BCStateTran::setReconfigurationEngineImpl(std::shared_ptr<ClientReconfigura
 template <typename MSG>
 void BCStateTran::freeStateTransferMsg(const MSG *m) {
   const char *p_to_delete = (reinterpret_cast<const char *>(m) - sizeof(MessageBase::Header));
+  if (m->isIncomingMsg_) {
+    MessageBase::Statistics::updateDiagnosticsCountersOnBufRelease(MsgCode::StateTransfer);
+  }
   std::free(const_cast<char *>(p_to_delete));
 }
 
@@ -1149,6 +1152,7 @@ void BCStateTran::handleStateTransferMessageImpl(char *msg,
                                                  LocalTimePoint incomingEventsQPushTime) {
   // msgHeader is now the owner of msg. after getting true type of msg, the ownership will be of onMessage functions.
   auto msgHeader = STMessageUptr<BCStateTranBaseMsg>(reinterpret_cast<BCStateTranBaseMsg *>(msg));
+  msgHeader.get()->isIncomingMsg_ = true;
   if (!running_) {
     return;
   }

--- a/bftengine/src/bcstatetransfer/Messages.hpp
+++ b/bftengine/src/bcstatetransfer/Messages.hpp
@@ -40,8 +40,12 @@ class MsgType {
 };
 
 struct BCStateTranBaseMsg {
-  BCStateTranBaseMsg(uint16_t type) : type(type) {}
+  BCStateTranBaseMsg(uint16_t type, bool isIncomingMsg = false) : type(type), isIncomingMsg_(isIncomingMsg) {}
+
   uint16_t type;
+  // this flag is for monitoring messages buffer allocs and releases so it's mutable even though incoming ST msgs objs
+  // are const during handling
+  mutable uint8_t isIncomingMsg_;
   // This struct and its derived structs are used to de/serialize message buffers sent over communication channels.
   // Since virtual methods modify the memory layout of a struct, there cannot be any for both this base struct and its
   // inheritors.
@@ -134,7 +138,7 @@ struct CheckpointSummaryMsg : public BCStateTranBaseMsg {
   }
 
   static bool equivalent(const CheckpointSummaryMsg* a, const CheckpointSummaryMsg* b) {
-    static_assert((sizeof(CheckpointSummaryMsg) - sizeof(requestMsgSeqNum) == 87),
+    static_assert((sizeof(CheckpointSummaryMsg) - sizeof(requestMsgSeqNum) == 88),
                   "Should newly added field be compared below?");
     bool cmp1 =
         ((a->maxBlockId == b->maxBlockId) && (a->checkpointNum == b->checkpointNum) &&
@@ -152,7 +156,7 @@ struct CheckpointSummaryMsg : public BCStateTranBaseMsg {
   }
 
   static bool equivalent(const CheckpointSummaryMsg* a, uint16_t a_id, const CheckpointSummaryMsg* b, uint16_t b_id) {
-    static_assert((sizeof(CheckpointSummaryMsg) - sizeof(requestMsgSeqNum) == 87),
+    static_assert((sizeof(CheckpointSummaryMsg) - sizeof(requestMsgSeqNum) == 88),
                   "Should newly added field be compared below?");
     if ((a->maxBlockId != b->maxBlockId) || (a->checkpointNum != b->checkpointNum) ||
         (a->digestOfMaxBlockId != b->digestOfMaxBlockId) ||

--- a/bftengine/src/bftengine/IncomingMsgsStorage.hpp
+++ b/bftengine/src/bftengine/IncomingMsgsStorage.hpp
@@ -20,6 +20,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 
 namespace bftEngine::impl {
 
@@ -30,6 +31,8 @@ class IncomingMsgsStorage {
 
   virtual void start() = 0;
   virtual void stop() = 0;
+  // returns a string with status. To be used by diagnostics server
+  virtual std::string status() const = 0;
 
   virtual bool isRunning() const = 0;
 

--- a/bftengine/src/bftengine/IncomingMsgsStorageImp.cpp
+++ b/bftengine/src/bftengine/IncomingMsgsStorageImp.cpp
@@ -13,8 +13,10 @@
 
 #include "IncomingMsgsStorageImp.hpp"
 #include "messages/InternalMessage.hpp"
-#include <future>
 #include "log/logger.hpp"
+
+#include <future>
+#include <sstream>
 
 using std::queue;
 using namespace std::chrono;
@@ -197,6 +199,19 @@ void IncomingMsgsStorageImp::dispatchMessages(std::promise<void>& signalStarted)
     LOG_FATAL(GL, "Exception: " << e.what() << "exiting ...");
     std::terminate();
   }
+}
+
+std::string IncomingMsgsStorageImp::status() const {
+  std::ostringstream oss;
+
+  bool is_running = isRunning();
+
+  oss << KVLOG(is_running) << std::endl;
+  oss << MessageBase::Statistics::getNumBuffsAllocatedForExtrnIncomingMsgs() << std::endl;
+  oss << MessageBase::Statistics::getNumBuffsFreedForExtrnIncomingMsgs() << std::endl;
+  oss << MessageBase::Statistics::getNumAliveExtrnIncomingMsgsObjsPerType() << std::endl;
+
+  return oss.str();
 }
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/IncomingMsgsStorageImp.hpp
+++ b/bftengine/src/bftengine/IncomingMsgsStorageImp.hpp
@@ -26,6 +26,7 @@
 #include <condition_variable>
 #include <future>
 #include <utility>
+#include <string>
 
 namespace bftEngine::impl {
 
@@ -38,6 +39,8 @@ class IncomingMsgsStorageImp : public IncomingMsgsStorage {
 
   void start() override;
   void stop() override;
+  // returns a string with status. To be used by diagnostics server
+  std::string status() const override;
 
   // Can be called by any thread
   bool pushExternalMsg(std::unique_ptr<MessageBase> msg) override;

--- a/bftengine/src/bftengine/MsgReceiver.cpp
+++ b/bftengine/src/bftengine/MsgReceiver.cpp
@@ -36,8 +36,8 @@ void MsgReceiver::onNewMessage(NodeNum sourceNode,
 
   auto *msgBody = (MessageBase::Header *)std::malloc(messageLength);
   memcpy(msgBody, message, messageLength);
-  auto pMsg = std::make_unique<MessageBase>(sourceNode, msgBody, messageLength, true);
-
+  auto pMsg = std::make_unique<MessageBase>(sourceNode, msgBody, messageLength, true, true);
+  MessageBase::Statistics::updateDiagnosticsCountersOnBufAlloc(static_cast<MsgCode::Type>(pMsg->type()));
   incomingMsgsStorage_->pushExternalMsg(std::move(pMsg));
 }
 

--- a/bftengine/src/bftengine/MsgsCommunicator.cpp
+++ b/bftengine/src/bftengine/MsgsCommunicator.cpp
@@ -12,6 +12,7 @@
 #include "MsgsCommunicator.hpp"
 #include "assertUtils.hpp"
 #include "communication/CommDefs.hpp"
+#include "diagnostics.h"
 
 namespace bftEngine::impl {
 
@@ -21,7 +22,14 @@ using namespace bft::communication;
 MsgsCommunicator::MsgsCommunicator(ICommunication* comm,
                                    shared_ptr<IncomingMsgsStorage> incomingMsgsStorage,
                                    shared_ptr<IReceiver> msgReceiver)
-    : incomingMsgsStorage_(incomingMsgsStorage), msgReceiver_(msgReceiver), communication_(comm) {}
+    : incomingMsgsStorage_(incomingMsgsStorage), msgReceiver_(msgReceiver), communication_(comm) {
+  auto& registrar = concord::diagnostics::RegistrarSingleton::getInstance();
+
+  concord::diagnostics::StatusHandler handler(
+      "messages_communicator", "Msg Comm", [this]() { return incomingMsgsStorage_->status(); });
+
+  registrar.status.registerHandler(handler);
+}
 
 int MsgsCommunicator::startCommunication(uint16_t replicaId) {
   replicaId_ = replicaId;

--- a/bftengine/src/bftengine/messages/MessageBase.cpp
+++ b/bftengine/src/bftengine/messages/MessageBase.cpp
@@ -9,13 +9,13 @@
 // these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
-#include <cstring>
-
 #include "MessageBase.hpp"
-
 #include "log/logger.hpp"
 #include "assertUtils.hpp"
 #include "ReplicaConfig.hpp"
+
+#include <cstring>
+#include <sstream>
 
 #ifdef DEBUG_MEMORY_MSG
 #include <set>
@@ -46,11 +46,66 @@ void MessageBase::printLiveMessages() {
 namespace bftEngine {
 namespace impl {
 
+// static class members for diagnostics server
+std::array<std::atomic<size_t>, MsgCode::LastMsgCodeVal> MessageBase::Statistics::AliveIncomingExtrnMsgsBufs{};
+static_assert(MsgCode::LastMsgCodeVal < 2000,
+              "MessageBase AliveIncomingExtrnMsgsBufs array too big (above 2000), check MsgCode enum definition");
+Bitmap MessageBase::Statistics::IncomingExtrnMsgReceivedAtLeastOnceFlags{MsgCode::LastMsgCodeVal};
+std::mutex MessageBase::Statistics::messagesStatsMonitoringMutex_{};
+std::atomic<size_t> MessageBase::Statistics::numIncomingExtrnMsgsBufAllocs{0};
+std::atomic<size_t> MessageBase::Statistics::numIncomingExtrnMsgsBufFrees{0};
+// End of static class members for diagnostics server
+
 MessageBase::~MessageBase() {
 #ifdef DEBUG_MEMORY_MSG
   liveMessagesDebug.erase(this);
 #endif
-  if (owner_) std::free((char *)msgBody_);
+
+  // if this obj is not the owner of the buf (owner_ is false), the buf may have already be freed - hence access to it
+  // is prohibited
+  if (owner_) {
+    if (isIncomingMsg_) {
+      MsgCode::Type msg_code = static_cast<MsgCode::Type>(msgBody_->msgType);
+      MessageBase::Statistics::updateDiagnosticsCountersOnBufRelease(msg_code);
+    }
+    std::free((char *)msgBody_);
+  }
+}
+
+void MessageBase::Statistics::updateDiagnosticsCountersOnBufAlloc(MsgCode::Type msg_code) {
+  if (!MessageBase::Statistics::IncomingExtrnMsgReceivedAtLeastOnceFlags.get(msg_code)) {
+    // here is a very rare event - first time ever receiving msg of type msg_code, hence
+    // using a lock here shouldn't affect performnce. in other places we avoid locks where possible.
+    // It is possible that two threads will call the "set" function but it's ok since it's
+    // just a flag telling us if the message was received at least once. setting the bit twice causes
+    // no damage.
+    std::lock_guard<std::mutex> lock(MessageBase::Statistics::messagesStatsMonitoringMutex_);
+    MessageBase::Statistics::IncomingExtrnMsgReceivedAtLeastOnceFlags.set(msg_code);
+  }
+
+  // use "++" operator to ensure atomicity
+  MessageBase::Statistics::numIncomingExtrnMsgsBufAllocs++;
+  MessageBase::Statistics::AliveIncomingExtrnMsgsBufs[msg_code]++;
+}
+
+void MessageBase::Statistics::updateDiagnosticsCountersOnBufRelease(MsgCode::Type msg_code) {
+  if (MessageBase::Statistics::AliveIncomingExtrnMsgsBufs[msg_code] == 0) {
+    LOG_ERROR(GL, "Trying to dec a counter of a msg that hasn't been inserted yet, msg code: " << (msg_code));
+    return;
+  } else {
+    // use "--" operator to ensure atomicity
+    MessageBase::Statistics::AliveIncomingExtrnMsgsBufs[msg_code]--;
+  }
+  // use "++" operator to ensure atomicity
+  MessageBase::Statistics::numIncomingExtrnMsgsBufFrees++;
+}
+
+void MessageBase::releaseOwnership() {
+  if (!owner_) {
+    LOG_ERROR(GL, "Trying to release ownership of a MessageBase obj that is already not the buffer owner");
+  } else {
+    owner_ = false;
+  }
 }
 
 void MessageBase::shrinkToFit() {
@@ -102,13 +157,17 @@ MessageBase::MessageBase(NodeIdType sender, MsgType type, SpanContextSize spanCo
 #endif
 }
 
-MessageBase::MessageBase(NodeIdType sender, MessageBase::Header *body, MsgSize size, bool ownerOfStorage) {
-  msgBody_ = body;
-  msgSize_ = size;
-  storageSize_ = size;
-  sender_ = sender;
-  owner_ = ownerOfStorage;
+MessageBase::MessageBase(NodeIdType sender, MessageBase::Header *body, MsgSize size, bool ownerOfStorage)
+    : MessageBase(sender, body, size, ownerOfStorage, false) {}
 
+MessageBase::MessageBase(
+    NodeIdType sender, MessageBase::Header *body, MsgSize size, bool ownerOfStorage, bool isIncoming)
+    : msgBody_(body),
+      msgSize_(size),
+      storageSize_(size),
+      sender_(sender),
+      owner_(ownerOfStorage),
+      isIncomingMsg_(isIncoming) {
 #ifdef DEBUG_MEMORY_MSG
   liveMessagesDebug.insert(this);
 #endif
@@ -234,6 +293,39 @@ MessageBase *MessageBase::deserializeMsg(char *&buf, size_t bufLen, size_t &actu
   actualSize = msgFilledFlagSize + msgSize;
   return msg;
 }
+
+// Start methods for diagnostics server:
+std::string MessageBase::Statistics::getNumBuffsAllocatedForExtrnIncomingMsgs() {
+  return (std::string(" Num buffer allocations for external incoming messages: " +
+                      std::to_string(MessageBase::Statistics::numIncomingExtrnMsgsBufAllocs)));
+}
+std::string MessageBase::Statistics::getNumBuffsFreedForExtrnIncomingMsgs() {
+  return (std::string(" Num buffer frees for external incoming messages: " +
+                      std::to_string(MessageBase::Statistics::numIncomingExtrnMsgsBufFrees)));
+}
+std::string MessageBase::Statistics::getNumAliveExtrnIncomingMsgsObjsPerType() {
+  std::ostringstream oss;
+  oss << " Alive extrnal incoming message objects per type: " << std::endl;
+  oss << " --------------------------------------- " << std::endl;
+
+  for (int i = 0; i < MsgCode::LastMsgCodeVal; ++i) {
+    bool wasMsgEverRecieved;
+
+    {
+      std::lock_guard<std::mutex> lock(messagesStatsMonitoringMutex_);
+      wasMsgEverRecieved = MessageBase::Statistics::IncomingExtrnMsgReceivedAtLeastOnceFlags.get(i);
+    }
+
+    if (wasMsgEverRecieved) {
+      oss << " " << static_cast<MsgCode::Type>(i) << ": " << MessageBase::Statistics::AliveIncomingExtrnMsgsBufs[i]
+          << std::endl;
+    }
+  }
+
+  oss << " ** All messages not on the list were never received by replica ** ";
+  return oss.str();
+}
+// End methods for diagnostics server ^
 
 }  // namespace impl
 }  // namespace bftEngine

--- a/bftengine/src/bftengine/messages/MessageBase.hpp
+++ b/bftengine/src/bftengine/messages/MessageBase.hpp
@@ -11,12 +11,17 @@
 
 #pragma once
 
-#include <type_traits>
 #include "OpenTracing.hpp"
 #include "SysConsts.hpp"
 #include "PrimitiveTypes.hpp"
 #include "MsgCode.hpp"
 #include "ReplicasInfo.hpp"
+#include "Bitmap.hpp"
+
+#include <type_traits>
+#include <atomic>
+#include <mutex>
+#include <array>
 
 namespace bftEngine {
 namespace impl {
@@ -40,7 +45,9 @@ class MessageBase {
 
   MessageBase(NodeIdType sender, Header *body, MsgSize size, bool ownerOfStorage);
 
-  void releaseOwnership() { owner_ = false; }
+  MessageBase(NodeIdType sender, Header *body, MsgSize size, bool ownerOfStorage, bool isIncoming);
+
+  void releaseOwnership();
 
   virtual ~MessageBase();
 
@@ -67,6 +74,8 @@ class MessageBase {
 
   SpanContextSize spanContextSize() const { return msgBody_->spanContextSize; }
 
+  bool isIncomingMsg() const { return isIncomingMsg_; }
+
   template <typename MessageT>
   concordUtils::SpanContext spanContext() const {
     return concordUtils::SpanContext{std::string(body() + sizeOfHeader<MessageT>(), spanContextSize())};
@@ -78,6 +87,29 @@ class MessageBase {
 #ifdef DEBUG_MEMORY_MSG
   static void printLiveMessages();
 #endif
+
+  struct Statistics {
+    // Static methods for reporting messages' status to diagnostics server:
+    static std::string getNumBuffsAllocatedForExtrnIncomingMsgs();
+    static std::string getNumBuffsFreedForExtrnIncomingMsgs();
+    static std::string getNumAliveExtrnIncomingMsgsObjsPerType();
+    // Static methods called when incoming messages' buffer are allocated or released - for monitoring.
+    static void updateDiagnosticsCountersOnBufRelease(MsgCode::Type msg_code);
+    static void updateDiagnosticsCountersOnBufAlloc(MsgCode::Type msg_code);
+
+   private:
+    // Static data structures gathering statistics for diagnostics server:
+
+    // although MsgCode::LastMsgCodeVal is much higher than the actual number of real message types,
+    // we allocate an array of size MsgCode::LastMsgCodeVal for simplicity and avoiding using locks,
+    // as this structures are a shared resource between threads.
+    static std::array<std::atomic<size_t>, MsgCode::LastMsgCodeVal> AliveIncomingExtrnMsgsBufs;
+    static Bitmap IncomingExtrnMsgReceivedAtLeastOnceFlags;
+    // the mutex is only locked once per message type - on the first time it is received
+    static std::mutex messagesStatsMonitoringMutex_;
+    static std::atomic<size_t> numIncomingExtrnMsgsBufAllocs;
+    static std::atomic<size_t> numIncomingExtrnMsgsBufFrees;
+  };
 
  protected:
   void writeObjAndMsgToLocalBuffer(char *buffer, size_t bufferLength, size_t *actualSize) const;
@@ -96,8 +128,10 @@ class MessageBase {
   MsgSize storageSize_ = 0;
   // This might be the direct sender, but not the originator
   NodeIdType sender_;
+
   // true IFF this instance is not responsible for de-allocating the body:
   bool owner_ = true;
+
   static constexpr uint32_t magicNumOfRawFormat = 0x5555897BU;
 
   template <typename MessageT>
@@ -111,6 +145,9 @@ class MessageBase {
 
   static constexpr uint64_t SPAN_CONTEXT_MAX_SIZE{1024};
   static constexpr uint32_t MAX_BATCH_SIZE{1024};
+
+  bool isIncomingMsg_ = false;
+
 #pragma pack(push, 1)
   struct RawHeaderOfObjAndMsg {
     uint32_t magicNum;
@@ -125,11 +162,14 @@ class MessageBase {
 // During de-serialization we first place the raw char array that we receive with the actual message into the msgBody_
 // of a MessageBase object to be able to get the msgType. Later during dispatch we need to create an object of the
 // actual message type from the MessageBase object holding the msgBody_ of the actual message.
-#define BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(TrueTypeName)                                                     \
-  TrueTypeName(MessageBase *msgBase)                                                                                \
-      : MessageBase(                                                                                                \
-            msgBase->senderId(), reinterpret_cast<MessageBase::Header *>(msgBase->body()), msgBase->size(), true) { \
-    msgBase->releaseOwnership();                                                                                    \
+#define BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(TrueTypeName)               \
+  TrueTypeName(MessageBase *msgBase)                                          \
+      : MessageBase(msgBase->senderId(),                                      \
+                    reinterpret_cast<MessageBase::Header *>(msgBase->body()), \
+                    msgBase->size(),                                          \
+                    true,                                                     \
+                    msgBase->isIncomingMsg()) {                               \
+    msgBase->releaseOwnership();                                              \
   }
 
 template <typename MessageT>

--- a/bftengine/src/bftengine/messages/MsgCode.hpp
+++ b/bftengine/src/bftengine/messages/MsgCode.hpp
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "kvstream.h"
+
 #include <cstdint>
 #include <sstream>
 
@@ -54,6 +56,7 @@ class MsgCode {
     ClientBatchRequest = 750,
     ClientReply = 800,
     Reserved = 900,
+    LastMsgCodeVal  // always keep this last in the enum as it is used to allocate array size(s)
   };
 };
 
@@ -134,14 +137,24 @@ inline std::ostream& operator<<(std::ostream& os, const MsgCode::Type& c) {
     case MsgCode::PreProcessReply:
       os << "PreProcessReply";
       break;
+    case MsgCode::PreProcessBatchRequest:
+      os << "PreProcessBatchRequest";
+      break;
+    case MsgCode::PreProcessBatchReply:
+      os << "PreProcessBatchReply";
+      break;
     case MsgCode::ClientRequest:
       os << "ClientRequest";
+      break;
+    case MsgCode::ClientBatchRequest:
+      os << "ClientBatchRequest";
       break;
     case MsgCode::ClientReply:
       os << "ClientReply";
       break;
     default:
-      os << "UNKNOWN";
+      auto msgCode = static_cast<uint16_t>(c);
+      os << "Unknown " << KVLOG(msgCode);
   }
   return os;
 }

--- a/ccron/test/include/ticks_generator_mocks.hpp
+++ b/ccron/test/include/ticks_generator_mocks.hpp
@@ -29,6 +29,7 @@ namespace concord::cron::test {
 struct IncomingMsgsStorageMock : public bftEngine::impl::IncomingMsgsStorage {
   void start() override{};
   void stop() override{};
+  std::string status() const override { return std::string(""); };
 
   bool isRunning() const override { return true; };
 

--- a/diagnostics/src/status_handlers.cpp
+++ b/diagnostics/src/status_handlers.cpp
@@ -22,8 +22,8 @@ static logging::Logger DIAG_LOGGER = logging::getLogger("concord.diag.status");
 void StatusHandlers::registerHandler(const StatusHandler& handler) {
   std::lock_guard<std::mutex> guard(mutex_);
   if (status_handlers_.count(handler.name)) {
-    LOG_FATAL(DIAG_LOGGER, "StatusHandler already exists: " << handler.name);
-    std::terminate();
+    LOG_ERROR(DIAG_LOGGER, "StatusHandler already exists: " << handler.name << ", ignoring the new handler");
+    return;
   }
   status_handlers_.insert({handler.name, handler});
 }


### PR DESCRIPTION
Motivation: a tool to monitor incoming messages' memory leaks. using a simple script one can periodically ask for a report about the number of mem buffers allocated (but not freed) for messages and see if the number is growing which may indicate a leak.


- MessageBase: add structures and functionality to gather stats about incoming msgs
- Every time an external incoming message arrives and a buffer is allocated, monitoring structures are updated
- Every time an external incoming message buffer is released, monitoring structures are updated
- A user can get the information in real time from diagnostics server:
- Run "./concord-ctl status get messages_communicator" from inside concord container